### PR TITLE
No ads outside production

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<% unless user_signed_in? %>
+<% if Rails.env.production? && !user_signed_in? %>
 <div class="row padded_nicely">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <!-- test1 -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,9 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
     <%= display_meta_tags :reverse => true, :site => 'Transbucket.com' %>
-    <script data-ad-client="ca-pub-3154444439610781" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+    <% if Rails.env.production? %>
+      <script data-ad-client="ca-pub-3154444439610781" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+    <% end %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
   </head>
   <body>

--- a/app/views/pins/_pin.html.erb
+++ b/app/views/pins/_pin.html.erb
@@ -1,4 +1,4 @@
-<% if rand(1..15) == 7 %>
+<% if Rails.env.production? && rand(1..15) == 7 %>
   <% Rails.logger.debug "Serving ad with #{pin.id}" %>
   <div class="item" class="ad">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>


### PR DESCRIPTION
To avoid test failures due to the ads code being loaded regardless of
environment and then erroring, this change ensures that we only load ads
code in production.

Test Plan:
- go to http://localhost:3003
- verify that there are no requests for `adsbygoogle`
- `rspec`