### PR TITLE
I18n of devise views + mailers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'figaro'
 # for i18n, pulls out header
 gem 'http_accept_language'
 gem 'rails-i18n', '~> 4.0'
+gem 'i18n_generators'
 
 # for authentication
 gem 'bcrypt', '~> 3.1.13'

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'figaro'
 
 # for i18n, pulls out header
 gem 'http_accept_language'
+gem 'rails-i18n', '~> 4.0'
 
 # for authentication
 gem 'bcrypt', '~> 3.1.13'

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ gem 'friendly_id', '~> 5.1.0' # Note: You MUST use 5.0.0 or greater for Rails 4.
 # for managing environment variables
 gem 'figaro'
 
+# for i18n, pulls out header
+gem 'http_accept_language'
+
 # for authentication
 gem 'bcrypt', '~> 3.1.13'
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'figaro'
 # for authentication
 gem 'bcrypt', '~> 3.1.13'
 gem 'devise'
+gem 'devise-i18n'
 gem 'devise-encryptable'
 
 gem 'aasm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,8 @@ GEM
       warden (~> 1.2.3)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
+    devise-i18n (1.5.1)
+      devise (>= 3.4)
     diff-lcs (1.4.4)
     disposable (0.2.6)
       declarative (~> 0.0.6)
@@ -496,6 +498,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   devise-encryptable
+  devise-i18n
   elasticsearch-model
   elasticsearch-rails
   factory_girl_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,12 +104,13 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
     callsite (0.0.11)
-    capybara (2.5.0)
-      mime-types (>= 1.16)
+    capybara (2.18.0)
+      addressable
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-email (2.5.0)
       capybara (~> 2.4)
       mail
@@ -259,7 +260,7 @@ GEM
     method_source (0.8.2)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0212)
+    mime-types-data (3.2021.0225)
     mimemagic (0.3.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -467,8 +468,8 @@ GEM
     will_paginate (3.0.7)
     will_paginate-bootstrap (1.0.1)
       will_paginate (>= 3.0.3)
-    xpath (2.1.0)
-      nokogiri (~> 1.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zip-codes (0.2.1)
 
 PLATFORMS

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (4.0.9)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -535,6 +538,7 @@ DEPENDENCIES
   quiet_assets
   rack-mini-profiler
   rails
+  rails-i18n (~> 4.0)
   rails_12factor
   rake-progressbar
   reform

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,9 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    i18n_generators (2.2.2)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     interception (0.5)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
@@ -517,6 +520,7 @@ DEPENDENCIES
   guard-rspec
   htmlentities
   http_accept_language
+  i18n_generators
   launchy
   letsrate
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,6 +222,7 @@ GEM
     highline (1.7.8)
     hike (1.2.3)
     htmlentities (4.3.4)
+    http_accept_language (2.1.1)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -511,6 +512,7 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   htmlentities
+  http_accept_language
   launchy
   letsrate
   letter_opener

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  include HttpAcceptLanguage::AutoLocale
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception

--- a/app/models/gender.rb
+++ b/app/models/gender.rb
@@ -1,4 +1,16 @@
 class Gender < ActiveRecord::Base
   attr_accessible :name
   has_many :users
+
+  def cis?
+    name.downcase == "cisgender"
+  end
+
+  def afab?
+    name.downcase == "FTM"
+  end
+
+  def amab?
+    name.downcase == "MTF"
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,23 @@
-<h2><%= t(".resend_confirmation_instructions") %></h2>
+<% title t(".resend_confirmation_instructions") %>
 
-<%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
-  <%= f.full_error :confirmation_token %>
+<div class="col-md-5 center">
+  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
+  <div class="login_well">
+    <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
+      <div class="input-group padded_nicely">
+        <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
+        <%= f.email_field :email, required:true, autofocus: true, class: "form-control" %>
+      </div>
+      <div class="padded_nicely">
+        <center>
+          <%= f.button :submit, t(".resend_confirmation_instructions"), class: "btn btn-info" %>
+        </center>
+      </div>
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
+    <% end %>
+    <div class="well">
+      <%= render "devise/shared/links" %>
+    </div>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, t(".resend_confirmation_instructions") %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,12 +9,9 @@
         <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
         <%= f.email_field :email, required:true, autofocus: true, class: "form-control" %>
       </div>
-      <div class="padded_nicely">
-        <center>
+      <div class="form-actions padded_nicely">
           <%= f.button :submit, t(".resend_confirmation_instructions"), class: "btn btn-info" %>
-        </center>
       </div>
-
     <% end %>
     <div class="well">
       <%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,18 +1,16 @@
-<% title 'Resend confirmation instructions' %>
-<div class="col-md-5 center">
-  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
-  <div class="login_well">
-    <%= form_for(resource, :as => resource_name, :url => confirmation_path(resource_name), :html => { :method => :post }) do |f| %>
-    <%= devise_error_messages! %>
-    <div class="input-group padded_nicely">
-      <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
-      <%= f.email_field :email, placeholder: "Email", class: "form-control", autofocus: true %>
-    </div>
-    <div>
-    <%= f.submit "Resend confirmation instructions",  class: "btn btn-info" %></div>
+<h2><%= t(".resend_confirmation_instructions") %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :confirmation_token %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
   </div>
-  <div class="well">
-    <%= render "devise/shared/links" %>
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".resend_confirmation_instructions") %>
   </div>
-</div>
 <% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -4,7 +4,7 @@
   <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
   <div class="login_well">
     <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= f.error_notification %>
       <div class="input-group padded_nicely">
         <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
         <%= f.email_field :email, required:true, autofocus: true, class: "form-control" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <% require 'devise/version' %>
-<p><%= t('.greeting', recipient: @resource.email) %></p>
+<p><%= t('.greeting', recipient: @email) %></p>
 
 <p><%= t('.instruction') %></p>
-<p><%= link_to t('.action'), confirmation_url(@resource, :confirmation_token => @token) %></p>
+<p><%= link_to t('.action'), confirmation_url(@resource, :confirmation_token => @token, :utm_medium => 'email', :utm_source => 'devise', :utm_campaign => 'confirmation') %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<% require 'devise/version' %>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
-
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @token, :utm_medium => 'email', :utm_source => 'devise', :utm_campaign => 'confirmation') %></p>
+<p><%= t('.instruction') %></p>
+<p><%= link_to t('.action'), confirmation_url(@resource, :confirmation_token => @token) %></p>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -2,7 +2,3 @@
 <p><%= t('.greeting', recipient: @resource.email) %></p>
 
 <p><%= t('.message') %></p>
-
-<p><%= t('.instruction') %></p>
-
-<p><%= link_to t('.action'), unlock_url(@resource, :unlock_token => @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,9 @@
-<p>Hello <%= @resource.email %>!</p>
+<% require 'devise/version' %>
+<p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.instruction') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, :reset_password_token => @token, :utm_medium => 'email', :utm_source => 'devise', :utm_campaign => 'reset') %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, :reset_password_token => @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.instruction_2') %></p>
+<p><%= t('.instruction_3') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,7 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, :reset_password_token => @token) %></p>
+<p><%= link_to t('.action'), edit_password_url(@resource, :reset_password_token => @token, :utm_medium => 'email', :utm_source => 'devise', :utm_campaign => 'reset') %></p>
 
 <p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -5,4 +5,4 @@
 
 <p><%= t('.instruction') %></p>
 
-<p><%= link_to t('.action'), unlock_url(@resource, :unlock_token => @token) %></p>
+<p><%= link_to t('.action'), unlock_url(@resource, :unlock_token => @token, :utm_medium => 'email', :utm_source => 'devise', :utm_campaign => 'unlock') %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,22 +1,19 @@
-<% title 'Change your password' %>
-<div class="col-md-5 center">
-  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
-  <div class="login_well">
-    <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :put }) do |f| %>
-    <%= devise_error_messages! %>
-    <%= f.hidden_field :reset_password_token %>
-    <div class="input-group padded_nicely">
-      <span class="input-group-addon"><%= fa_icon "lock" %></span>
-      <%= f.password_field :password, placeholder: "New password", class: "form-control", autofocus: true %>
-    </div>
-    <div class="input-group padded_nicely">
-      <span class="input-group-addon"><%= fa_icon "lock" %><%= fa_icon "check" %></span>
-      <%= f.password_field :password_confirmation, placeholder: "New password confirmation", class: "form-control" %>
-    </div>
-    <%= f.submit "Change my password", class: "btn btn-info" %>
+<h2><%= t(".change_your_password") %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.error_notification %>
+
+  <%= f.input :reset_password_token, as: :hidden %>
+  <%= f.full_error :reset_password_token %>
+
+  <div class="form-inputs">
+    <%= f.input :password, label: t(".new_password"), required: true, autofocus: true %>
+    <%= f.input :password_confirmation, label: t(".confirm_new_password"), required: true %>
   </div>
-  <div class="well">
-    <%= render "devise/shared/links" %>
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".change_my_password") %>
   </div>
-</div>
 <% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,19 +1,35 @@
-<h2><%= t(".change_your_password") %></h2>
-
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
-
-  <%= f.input :reset_password_token, as: :hidden %>
-  <%= f.full_error :reset_password_token %>
-
-  <div class="form-inputs">
-    <%= f.input :password, label: t(".new_password"), required: true, autofocus: true %>
-    <%= f.input :password_confirmation, label: t(".confirm_new_password"), required: true %>
+<% title t(".change_your_password") %>
+<div class="col-md-6 center">
+  <div class="top-block">
+    <center>
+      <h1>
+        <%= fa_icon "unlock-alt" %>
+      </h1>
+    </center>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, t(".change_my_password") %>
-  </div>
-<% end %>
+  <div class="login_well">
 
-<%= render "devise/shared/links" %>
+    <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: 'form-horizontal' }) do |f| %>
+      <%= f.error_notification %>
+
+      <%= f.input :reset_password_token, as: :hidden %>
+      <%= f.full_error :reset_password_token %>
+
+      <div class="input-group input-group-lg padded_nicely">
+        <span class="input-group-addon"><%= fa_icon "lock" %></span>
+
+        <%= f.input :password, label: t(".new_password"), required: true, autofocus: true %>
+        <%= f.input :password_confirmation, label: t(".confirm_new_password"), required: true %>
+      </div>
+
+      <div class="form-actions padded_nicely">
+        <%= f.button :submit, t(".change_my_password"), class: "btn btn-primary btn-large" %>
+      </div>
+    <% end %>
+
+  </div>
+  <div class="well">
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,15 +1,25 @@
-<h2><%= t(".forgot_your_password") %></h2>
+<% title t(".forgot_your_password") %>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
+<div class="col-md-5 center">
+  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
+  <div class="login_well">
 
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
+    <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= devise_error_messages! %>
+
+      <div class="input-group padded_nicely">
+        <span class="input-group-addon"><i class="glyphicon glyphicon-envelope">
+          </i></span>
+          <%= f.email_field :email, required: true, autofocus: true, class: "form-control" %>
+      </div>
+
+      <div class="form-actions">
+        <%= f.button :submit, t(".send_me_reset_password_instructions"), class: "btn btn-info" %>
+      </div>
+    <% end %>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, t(".send_me_reset_password_instructions") %>
+  <div class="well">
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -8,9 +8,8 @@
       <%= f.error_notification %>
 
       <div class="input-group padded_nicely">
-        <span class="input-group-addon"><i class="glyphicon glyphicon-envelope">
-          </i></span>
-          <%= f.email_field :email, required: true, autofocus: true, class: "form-control" %>
+        <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
+        <%= f.email_field :email, placeholder: t("activerecord.attributes.user.email"), required: true, autofocus: true, class: "form-control" %>
       </div>
 
       <div class="form-actions">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,17 +1,15 @@
-<% title 'Forgot your password?' %>
-<div class="col-md-5 center">
-  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
-  <div class="login_well">
-    <%= form_for(resource, :as => resource_name, :url => password_path(resource_name), :html => { :method => :post }) do |f| %>
-    <%= devise_error_messages! %>
-    <div class="input-group padded_nicely">
-      <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
-      <%= f.email_field :email, placeholder: "Email", class: "form-control", autofocus: true %>
-    </div>
-    <%= f.submit "Send me reset password instructions", class: "btn btn-info" %>
+<h2><%= t(".forgot_your_password") %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
   </div>
-  <div class="well">
-    <%= render "devise/shared/links" %>
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".send_me_reset_password_instructions") %>
   </div>
-</div>
 <% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,7 +5,7 @@
   <div class="login_well">
 
     <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= f.error_notification %>
 
       <div class="input-group padded_nicely">
         <span class="input-group-addon"><i class="glyphicon glyphicon-envelope">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,10 +1,29 @@
-<div class="row">
-  <div class="col-md-5">
-    <%= render 'users/profile', locals: {resource_name: resource_name} %>
-    <%= render 'users/settings', locals: {resource_name: resource_name} %>
+<h2><%= t(".title", resource: resource_class.model_name.human) %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <p>
+        <%= t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) %>
+      </p>
+    <% end %>
+
+    <%= f.input :password, autocomplete: "off", hint: t(".leave_blank_if_you_don_t_want_to_change_it"), required: false %>
+    <%= f.input :password_confirmation, required: false %>
+    <%= f.input :current_password, hint: t(".we_need_your_current_password_to_confirm_your_changes"), required: true %>
   </div>
-  <div class="col-md-6">
-    <%= render 'users/submissions', locals: {resource_name: resource_name} %>
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".update") %>
   </div>
-</div>
-<br clear="both">
+<% end %>
+
+<h3><%= t(".cancel_my_account") %></h3>
+
+<p><%= t(".unhappy") %> <%= link_to t(".cancel_my_account"), registration_path(resource_name), data: { confirm: t(".are_you_sure") }, method: :delete %></p>
+
+<%= link_to t("devise.shared.links.back"), :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,29 +1,10 @@
-<h2><%= t(".title", resource: resource_class.model_name.human) %></h2>
-
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
-
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
-
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <p>
-        <%= t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) %>
-      </p>
-    <% end %>
-
-    <%= f.input :password, autocomplete: "off", hint: t(".leave_blank_if_you_don_t_want_to_change_it"), required: false %>
-    <%= f.input :password_confirmation, required: false %>
-    <%= f.input :current_password, hint: t(".we_need_your_current_password_to_confirm_your_changes"), required: true %>
+<div class="row">
+  <div class="col-md-5">
+    <%= render 'users/profile', locals: {resource_name: resource_name} %>
+    <%= render 'users/settings', locals: {resource_name: resource_name} %>
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, t(".update") %>
+  <div class="col-md-6">
+    <%= render 'users/submissions', locals: {resource_name: resource_name} %>
   </div>
-<% end %>
-
-<h3><%= t(".cancel_my_account") %></h3>
-
-<p><%= t(".unhappy") %> <%= link_to t(".cancel_my_account"), registration_path(resource_name), data: { confirm: t(".are_you_sure") }, method: :delete %></p>
-
-<%= link_to t("devise.shared.links.back"), :back %>
+</div>
+<br clear="both">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,17 +1,57 @@
-<h2><%= t(".sign_up") %></h2>
-
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= f.error_notification %>
-
-  <div class="form-inputs">
-    <%= f.input :email, required: true, autofocus: true %>
-    <%= f.input :password, required: true %>
-    <%= f.input :password_confirmation, required: true %>
+<% title t(".sign_up") %>
+<div class="col-md-6 center">
+  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
+  <div class="login_well">
+    <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-horizontal'}) do |f| %>
+      <%= render 'shared/errors', object: resource %>
+      <div id="username">
+        <span class="explanation">Your <b>username</b> will be visible to all users and is what you use to log in. It is unique across the site.</span>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><%= fa_icon "users" %></span>
+          <%= f.text_field :username, placeholder: "Username", class: "form-control" %>
+        </div>
+      </div>
+      <div id="email">
+        <span class="explanation">Your <b>email</b> will be visible to admins but not other users. Your email will be confirmed.</span>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
+          <%= f.email_field :email, placeholder: "Email", class: "form-control" %>
+        </div>
+      </div>
+      <div id="password">
+        <span class="explanation">Your <b>password</b> will be encrypted when stored, and can be recovered using your email.</span>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><%= fa_icon "lock" %></span>
+          <%= f.password_field :password, placeholder: "Password", class: "form-control" %>
+        </div>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><%= fa_icon "lock" %><%= fa_icon "check" %></span>
+          <%= f.password_field :password_confirmation, placeholder: "Password confirmation", class: "form-control" %>
+        </div>
+      </div>
+      <div id="name">
+        <span class="explanation">Your <b>name</b> will be visible to admins and used in communications with them. If you are a care provider and do not use your real name, you will be blocked from the site.</span>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
+          <%= f.text_field :name, placeholder: "Your name", class: "form-control" %>
+        </div>
+      </div>
+      <div id="gender">
+        <span class="explanation">Your <b>gender</b> will be visible to everyone when you post results. It is also used to set some defaults for what content you see and your pronouns. It can be updated after registration.</span>
+        <div class="input-group padded_nicely">
+          <span class="input-group-addon"><%= fa_icon "key" %> Gender: </span>
+          <%= f.select :gender_id, options_from_collection_for_select(Gender.all, "id", "name"), {}, { class: "form-control"} %>
+        </div>
+      </div>
+      <p>By registering on Transbucket.com <b>you agree</b> to follow our <%= link_to "Terms of Service", terms_path %>.
+      </p>
+      <center>
+        <%= f.submit t(".sign_up"), class: "btn btn-primary btn-large" %>
+      </center>
+    <% end %>
+    <br clear="both">
   </div>
-
-  <div class="form-actions">
-    <%= f.button :submit, t(".sign_up") %>
+  <div class="well">
+    <%= render "devise/shared/links" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,7 @@
         <span class="explanation">Your <b>username</b> will be visible to all users and is what you use to log in. It is unique across the site.</span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "users" %></span>
-          <%= f.text_field :username, placeholder: t("activerecord.models.user"), class: "form-control" %>
+          <%= f.text_field :username, placeholder: "Username", class: "form-control" %>
         </div>
       </div>
       <div id="email">
@@ -22,7 +22,7 @@
         <span class="explanation">Your <b>password</b> will be encrypted when stored, and can be recovered using your email.</span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "lock" %></span>
-          <%= f.password_field :password, placeholder: t("activerecord.attributes.user.email"), class: "form-control" %>
+          <%= f.password_field :password, placeholder: t("activerecord.attributes.user.password"), class: "form-control" %>
         </div>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "lock" %><%= fa_icon "check" %></span>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,57 +1,17 @@
-<% title 'New Registration' %>
-<div class="col-md-6 center">
-  <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
-  <div class="login_well">
-    <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-horizontal'}) do |f| %>
-      <%= render 'shared/errors', object: resource %>
-      <div id="username">
-        <span class="explanation">Your <b>username</b> will be visible to all users and is what you use to log in. It is unique across the site.</span>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><%= fa_icon "users" %></span>
-          <%= f.text_field :username, placeholder: "Username", class: "form-control" %>
-        </div>
-      </div>
-      <div id="email">
-        <span class="explanation">Your <b>email</b> will be visible to admins but not other users. Your email will be confirmed.</span>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
-          <%= f.email_field :email, placeholder: "Email", class: "form-control" %>
-        </div>
-      </div>
-      <div id="password">
-        <span class="explanation">Your <b>password</b> will be encrypted when stored, and can be recovered using your email.</span>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><%= fa_icon "lock" %></span>
-          <%= f.password_field :password, placeholder: "Password", class: "form-control" %>
-        </div>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><%= fa_icon "lock" %><%= fa_icon "check" %></span>
-          <%= f.password_field :password_confirmation, placeholder: "Password confirmation", class: "form-control" %>
-        </div>
-      </div>
-      <div id="name">
-        <span class="explanation">Your <b>name</b> will be visible to admins and used in communications with them. If you are a care provider and do not use your real name, you will be blocked from the site.</span>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
-          <%= f.text_field :name, placeholder: "Your name", class: "form-control" %>
-        </div>
-      </div>
-      <div id="gender">
-        <span class="explanation">Your <b>gender</b> will be visible to everyone when you post results. It is also used to set some defaults for what content you see and your pronouns. It can be updated after registration.</span>
-        <div class="input-group padded_nicely">
-          <span class="input-group-addon"><%= fa_icon "key" %> Gender: </span>
-          <%= f.select :gender_id, options_from_collection_for_select(Gender.all, "id", "name"), {}, { class: "form-control"} %>
-        </div>
-      </div>
-      <p>By registering on Transbucket.com <b>you agree</b> to follow our <%= link_to "Terms of Service", terms_path %>.
-      </p>
-      <center>
-        <%= f.submit "Submit", class: "btn btn-primary btn-large" %>
-      </center>
-    <% end %>
-    <br clear="both">
+<h2><%= t(".sign_up") %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+    <%= f.input :password, required: true %>
+    <%= f.input :password_confirmation, required: true %>
   </div>
-  <div class="well">
-    <%= render "devise/shared/links" %>
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".sign_up") %>
   </div>
-</div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<% title t(".sign_up") %>
+<% title t('.sign_up') %>
 <div class="col-md-6 center">
   <div class="top-block"><center><h1><%= fa_icon "lock" %></h1></center></div>
   <div class="login_well">
@@ -8,21 +8,21 @@
         <span class="explanation">Your <b>username</b> will be visible to all users and is what you use to log in. It is unique across the site.</span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "users" %></span>
-          <%= f.text_field :username, placeholder: "Username", class: "form-control" %>
+          <%= f.text_field :username, placeholder: t("activerecord.models.user"), class: "form-control" %>
         </div>
       </div>
       <div id="email">
         <span class="explanation">Your <b>email</b> will be visible to admins but not other users. Your email will be confirmed.</span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
-          <%= f.email_field :email, placeholder: "Email", class: "form-control" %>
+          <%= f.email_field :email, placeholder: t("activerecord.attributes.user.email"), class: "form-control" %>
         </div>
       </div>
       <div id="password">
         <span class="explanation">Your <b>password</b> will be encrypted when stored, and can be recovered using your email.</span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "lock" %></span>
-          <%= f.password_field :password, placeholder: "Password", class: "form-control" %>
+          <%= f.password_field :password, placeholder: t("activerecord.attributes.user.email"), class: "form-control" %>
         </div>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "lock" %><%= fa_icon "check" %></span>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,21 +5,21 @@
     <%= simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), html: { class: 'form-horizontal'}) do |f| %>
       <%= render 'shared/errors', object: resource %>
       <div id="username">
-        <span class="explanation">Your <b>username</b> will be visible to all users and is what you use to log in. It is unique across the site.</span>
+        <span class="explanation"><%= I18n.t(".explanations.username") %></span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "users" %></span>
           <%= f.text_field :username, placeholder: "Username", class: "form-control" %>
         </div>
       </div>
       <div id="email">
-        <span class="explanation">Your <b>email</b> will be visible to admins but not other users. Your email will be confirmed.</span>
+        <span class="explanation"><%= I18n.t(".explanations.email") %></span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><i class="glyphicon glyphicon-envelope"></i></span>
           <%= f.email_field :email, placeholder: t("activerecord.attributes.user.email"), class: "form-control" %>
         </div>
       </div>
       <div id="password">
-        <span class="explanation">Your <b>password</b> will be encrypted when stored, and can be recovered using your email.</span>
+        <span class="explanation"><%= I18n.t(".explanations.password") %></span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "lock" %></span>
           <%= f.password_field :password, placeholder: t("activerecord.attributes.user.password"), class: "form-control" %>
@@ -30,21 +30,20 @@
         </div>
       </div>
       <div id="name">
-        <span class="explanation">Your <b>name</b> will be visible to admins and used in communications with them. If you are a care provider and do not use your real name, you will be blocked from the site.</span>
+        <span class="explanation"><%= I18n.t(".explanations.name") %></span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><i class="glyphicon glyphicon-user"></i></span>
           <%= f.text_field :name, placeholder: "Your name", class: "form-control" %>
         </div>
       </div>
       <div id="gender">
-        <span class="explanation">Your <b>gender</b> will be visible to everyone when you post results. It is also used to set some defaults for what content you see and your pronouns. It can be updated after registration.</span>
+        <span class="explanation"><%= I18n.t(".explanations.gender") %></span>
         <div class="input-group padded_nicely">
           <span class="input-group-addon"><%= fa_icon "key" %> Gender: </span>
           <%= f.select :gender_id, options_from_collection_for_select(Gender.all, "id", "name"), {}, { class: "form-control"} %>
         </div>
       </div>
-      <p>By registering on Transbucket.com <b>you agree</b> to follow our <%= link_to "Terms of Service", terms_path %>.
-      </p>
+      <p><%= I18n.t(".explanations.tos") %></p>
       <center>
         <%= f.submit t(".sign_up"), class: "btn btn-primary btn-large" %>
       </center>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,38 +1,15 @@
-<% title 'Sign In' %>
-<div class="col-md-6 center">
-  <div class="top-block">
-    <center>
-      <h1>
-        <%= fa_icon "unlock-alt" %>
-      </h1>
-    </center>
+<h2><%= t(".sign_in") %></h2>
+
+<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="form-inputs">
+    <%= f.input :email, required: false, autofocus: true %>
+    <%= f.input :password, required: false %>
+    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
   </div>
-  <div class="login_well">
-    <div id="flash-message">
-      <% flash.each do |name, msg| %>
-        <%= content_tag(:div, msg, class: "alert", id: "flash-#{name}") %>
-      <% end %>
-    </div>
-    <%= simple_form_for(resource, :as => resource_name, :url => session_path(resource_name), html: { class: 'form-horizontal'}) do |f| %>
-      <%= f.error_notification %>
-      <div class="input-group input-group-lg padded_nicely">
-        <span class="input-group-addon"><%= fa_icon "users" %></span>
-        <%= f.text_field :login, placeholder: "Username", class: "form-control" %>
-        <span class="input-group-addon">
-          <small>remember me?</small> <%= f.check_box :remember_me, as: :boolean %>
-      </span>
-    </div>
-    <div class="input-group input-group-lg padded_nicely">
-      <span class="input-group-addon"><%= fa_icon "lock" %></span>
-      <%= f.password_field :password, placeholder: "Password", class: "form-control" %>
-      <span class="input-group-btn">
-        <%= f.submit "Sign in", class: "btn btn-primary btn-large" %>
-      </span>
-    </div>
-  <% end %>
-</div>
-<div class="well">
-  <%= render "devise/shared/links" %>
-</div>
-</div>
-<br clear="both">
+
+  <div class="form-actions">
+    <%= f.button :submit, t(".sign_in") %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
       <%= f.error_notification %>
       <div class="input-group input-group-lg padded_nicely">
         <span class="input-group-addon"><%= fa_icon "users" %></span>
-        <%= f.text_field :login, placeholder: t('.sign_in'), autofocus: true, class: "form-control" %>
+        <%= f.text_field :login, placeholder: "Username", autofocus: true, class: "form-control" %>
         <span class="input-group-addon">
           <small>
             <%= t('.remember_me') %>?

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -22,7 +22,7 @@
         <%= f.text_field :login, placeholder: "Username", autofocus: true, class: "form-control" %>
         <span class="input-group-addon">
           <small>
-            <%= t('.remember_me') %>?
+            <%= t('activerecord.attributes.user.remember_me') %>?
           </small>
           <%= f.check_box :remember_me, as: :boolean %>
         </span>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,15 +1,43 @@
-<h2><%= t(".sign_in") %></h2>
+<% title t(".sign_in") %>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :email, required: false, autofocus: true %>
-    <%= f.input :password, required: false %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+<div class="col-md-6 center">
+  <div class="top-block">
+    <center>
+      <h1>
+        <%= fa_icon "unlock-alt" %>
+      </h1>
+    </center>
   </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, t(".sign_in") %>
+  <div class="login_well">
+    <div id="flash-message">
+      <% flash.each do |name, msg| %>
+        <%= content_tag(:div, msg, class: 'alert', id: "flash-#{name}") %>
+      <% end %>
+    </div>
+    <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'form-horizontal'}) do |f| %>
+      <%= f.error_notification %>
+      <div class="input-group input-group-lg padded_nicely">
+        <span class="input-group-addon"><%= fa_icon "users" %></span>
+        <%= f.text_field :login, placeholder: t('.sign_in'), autofocus: true, class: "form-control" %>
+        <span class="input-group-addon">
+          <small>
+            <%= t('.remember_me') %>?
+          </small>
+          <%= f.check_box :remember_me, as: :boolean %>
+        </span>
+      </div>
+      <div class="input-group input-group-lg padded_nicely">
+        <span class="input-group-addon"><%= fa_icon "lock" %></span>
+        <%= f.password_field :password, placeholder: 'Password', class: "form-control" %>
+
+        <span class="input-group-btn">
+          <%= f.button :submit, t(".sign_in"), class: "btn btn-primary btn-large" %>
+        </span>
+      </div>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<div class="well">
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to t(".sign_in"), new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to t(".sign_up"), new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' %>
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to t('.sign_in_with_provider', provider: provider.to_s.titleize), omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,12 +1,16 @@
-<h2><%= title 'Resend unlock instructions' %></h2>
+<h2><%= t(".resend_unlock_instructions") %></h2>
 
-<%= form_for(resource, :as => resource_name, :url => unlock_path(resource_name), :html => { :method => :post }) do |f| %>
-  <%= devise_error_messages! %>
+<%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :unlock_token %>
 
-  <div><%= f.label :email %><br />
-  <%= f.email_field :email, :autofocus => true %></div>
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+  </div>
 
-  <div><%= f.submit "Resend unlock instructions" %></div>
+  <div class="form-actions">
+    <%= f.button :submit, t(".resend_unlock_instructions") %>
+  </div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2><%= t(".resend_unlock_instructions") %></h2>
+<% title t(".resend_unlock_instructions") %>
 
 <%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.error_notification %>

--- a/app/views/layouts/_account_menu.html.erb
+++ b/app/views/layouts/_account_menu.html.erb
@@ -1,16 +1,16 @@
-<% cache do %>
-<ul class="nav navbar-nav">
-  <li class="dropdown">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Account <span class="caret"></span></a>
-    <ul class="dropdown-menu" role="menu">
-      <% if user_signed_in? %>
-      <li><%= link_to 'My Account',  edit_user_registration_path %></li>
-      <li><%= link_to 'Logout',  destroy_user_session_path, method: :delete %></li>
-      <% else %>
-      <li><%= link_to 'Register', register_path %></li>
-      <li><%= link_to 'Login',  new_user_session_path %></li>
-      <% end %>
-    </ul>
-  </li>
-</ul>
+<% cache(I18n.locale) do %>
+  <ul class="nav navbar-nav">
+    <li class="dropdown">
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t(".header.account")%> <span class="caret"></span></a>
+      <ul class="dropdown-menu" role="menu">
+        <% if user_signed_in? %>
+          <li><%= link_to I18n.t(".account_menu.my_account"),  edit_user_registration_path %></li>
+          <li><%= link_to I18n.t(".account_menu.logout"),  destroy_user_session_path, method: :delete %></li>
+        <% else %>
+          <li><%= link_to I18n.t(".account_menu.login"),  new_user_session_path %></li>
+          <li><%= link_to I18n.t(".account_menu.register"), register_path %></li>
+        <% end %>
+      </ul>
+    </li>
+  </ul>
 <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="footer navbar-fixed-bottom submission_well">
-<% cache(I18n.locale || Date.today.year) do %>
-  <small> &nbsp;
-  <b><%= Date.today.year %></b> &copy; Transbucket.com |
-  <%= link_to I18n.t('.footer.about'),  about_path %> |
-  <%= link_to I18n.t('.footer.tos'), terms_path %> |
-  <%= link_to I18n.t('.footer.pp'), privacy_path %>
-  </small>
-<% end %>
+  <% cache("#{I18n.locale}_#{Date.today.year}") do %>
+    <small> &nbsp;
+      <b><%= Date.today.year %></b> - Transbucket.com |
+      <%= link_to I18n.t('.footer.about'),  about_path %> |
+      <%= link_to I18n.t('.footer.tos'), terms_path %> |
+      <%= link_to I18n.t('.footer.pp'), privacy_path %>
+    </small>
+  <% end %>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,10 +1,10 @@
 <div class="footer navbar-fixed-bottom submission_well">
-<% cache(Date.today.year) do %>
+<% cache(I18n.locale || Date.today.year) do %>
   <small> &nbsp;
   <b><%= Date.today.year %></b> &copy; Transbucket.com |
-  <%= link_to 'About',  about_path %> |
-  <%= link_to 'Terms of Service', terms_path %> |
-  <%= link_to 'Privacy Policy', privacy_path %>
+  <%= link_to I18n.t('.footer.about'),  about_path %> |
+  <%= link_to I18n.t('.footer.tos'), terms_path %> |
+  <%= link_to I18n.t('.footer.pp'), privacy_path %>
   </small>
 <% end %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<% cache do %>
+<% cache(I18n.locale) do %>
   <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
@@ -18,13 +18,13 @@
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
         <ul class="nav navbar-nav">
           <li>
-            <%= link_to 'News',  newsfeed_path %>
+            <%= link_to I18n.t('.header.news'),  newsfeed_path %>
           </li>
           <li>
-            <%= link_to 'Procedures',  procedures_path %>
+            <%= link_to I18n.t('.header.procedures'),  procedures_path %>
           </li>
           <li>
-            <%= link_to 'Surgeons',  surgeons_path %>
+            <%= link_to I18n.t('.header.surgeons'),  surgeons_path %>
           </li>
         <% end %>
         <% if user_signed_in? %>

--- a/app/views/layouts/_logged_in.html.erb
+++ b/app/views/layouts/_logged_in.html.erb
@@ -1,27 +1,27 @@
 <% if current_user.admin? %>
-<li class="bg-danger">
-  <%= link_to 'ModQueue', queendom_path %>
-</li>
+  <li class="bg-danger">
+    <%= link_to 'ModQueue', queendom_path %>
+  </li>
 <% end %>
 <li>
-  <%= link_to 'Submissions', pins_path %>
+  <%= link_to I18n.t(".header.submissions"), pins_path %>
 </li>
 <% if current_page?(pins_path) %>
-<li class="dropdown">
-  <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-    Filter <span class="caret"></span>
-  </a>
-  <ul class="dropdown-menu" role="menu">
-    <li>
-      <%= render partial: 'pins/filter_controls' %>
-    </li>
-  </ul>
-</li>
+  <li class="dropdown">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+      <%= I18n.t(".header.filter") %> <span class="caret"></span>
+    </a>
+    <ul class="dropdown-menu" role="menu">
+      <li>
+        <%= render partial: 'pins/filter_controls' %>
+      </li>
+    </ul>
+  </li>
 <% end %>
-<% unless current_user.gender == "cisgender" %>
-<li>
-  <%= link_to "Add #{fa_icon('plus-circle yellow')}".html_safe, new_pin_path %>
-</li>
+<% unless current_user.gender.cis? %>
+  <li>
+    <%= link_to "#{I18n.t(".header.add")} #{fa_icon('plus-circle yellow')}".html_safe, new_pin_path %>
+  </li>
 <% end %>
 </ul>
 <%= render partial: 'layouts/search' %>

--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -1,8 +1,8 @@
-<% cache do %>
+<% cache(I18n.locale) do %>
   <%= javascript_include_tag 'search' %>
   <%= form_tag pins_path, :class => 'navbar-form navbar-right', :method => :get do %>
     <div class="input-group">
-      <%= text_field_tag 'query', value = nil, :class => 'span2 search-query form-control', :placeholder => "Search" %>
+      <%= text_field_tag 'query', value = nil, :class => 'span2 search-query form-control', :placeholder => I18n.t(".header.search") %>
       <%#= autocomplete_field_tag 'pin', '', autocomplete_procedure_pin_index_path, :size => 75 %>
       <div class="input-group-btn">
         <%= button_tag '', :class => 'btn btn-default glyphicon glyphicon-search' %>

--- a/app/views/pages/_welcome.html.erb
+++ b/app/views/pages/_welcome.html.erb
@@ -1,15 +1,16 @@
+<% title I18n.t('.homepage.title') %>
 <div class="row">
 <center>
   <div class="col-md-4">
-    <h3><%= title 'Are you considering transition care?' %></h3>
+    <h3><%= title I18n.t('.homepage.considering') %></h3>
     <%= link_to (image_tag("dysphoria2.png", :size => "200x200", :alt => "dysphoria", :padding => "10")), register_path %>
   </div>
   <div class="col-md-4">
-    <h3>You should join the community.</h3>
+    <h3><%= I18n.t('.homepage.join') %></h3>
     <%= link_to (image_tag("dysphoria3.png", :size => "200x200", :alt => "key", :padding => "10")), register_path %>
   </div>
   <div class="col-md-4">
-    <h3><%= link_to "Register to see real results.", register_path %></h3>
+    <h3><%= link_to I18n.t('.homepage.register'), register_path %></h3>
     <%= link_to (image_tag("register.png", :size => "200x200", :alt => "key", :padding => "10")), register_path %>
   </div>
 </center>

--- a/app/views/users/_settings.html.erb
+++ b/app/views/users/_settings.html.erb
@@ -1,4 +1,5 @@
-<h2>Edit <%= resource_name.to_s.humanize %> Settings</h2>
+<% title t(".title", resource: resource_name.to_s.humanize) %>
+
 <div class="profile_well">
   <%= simple_form_for(resource.preference, :url => user_preferences_path(resource), :html => {:method => :put, :class => 'form-horizontal'}) do |f| %>
     <%= render 'shared/errors', object: resource.preference %>
@@ -26,12 +27,12 @@
     <div class="col-lg-6">
       <p>Notification mode allows you to receive emails alerting you to new comments on your submission.</p>
     </div>
-    <%= f.submit "Update", class: "btn btn-primary pull-right" %>
+    <%= f.submit t("devise.registrations.edit.update"), class: "btn btn-primary pull-right" %>
     <br clear="both">
   <% end %>
 </div>
-<h2>Cancel <%= resource_name.to_s.humanize %> Account</h2>
+<h2><%= t("devise.registrations.edit.cancel_my_account") %></h2>
 <div class="well">
   <h3>Warning: this action CAN NOT be undone.</h3>
-  <%= button_to "Cancel my account", registration_path(resource_name), :data => { :confirm => "Are you sure?" }, :method => :delete, :class => 'btn' %>
+  <%= button_to t("devise.registrations.edit.cancel_my_account"), registration_path(resource_name), :data => { :confirm => t("devise.registrations.edit.are_you_sure") }, :method => :delete, :class => 'btn' %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Transbucket
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :en
     config.active_record.whitelist_attributes = false
 
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/initializers/i18n_defaults.rb
+++ b/config/initializers/i18n_defaults.rb
@@ -1,0 +1,10 @@
+i18n_simple_backend = I18n::Backend::Simple.new
+old_handler = I18n.exception_handler
+I18n.exception_handler = lambda do |exception, locale, key, options|
+  case exception
+  when I18n::MissingTranslation
+    i18n_simple_backend.translate(:en, key, options || {})
+  else
+    old_handler.call(exception, locale, key, options)
+  end
+end

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,249 @@
+---
+de:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz
+            existiert.
+          has_many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
+  date:
+    abbr_day_names:
+    - So
+    - Mo
+    - Di
+    - Mi
+    - Do
+    - Fr
+    - Sa
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mär
+    - Apr
+    - Mai
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Okt
+    - Nov
+    - Dez
+    day_names:
+    - Sonntag
+    - Montag
+    - Dienstag
+    - Mittwoch
+    - Donnerstag
+    - Freitag
+    - Samstag
+    formats:
+      default: "%d.%m.%Y"
+      long: "%e. %B %Y"
+      short: "%e. %b"
+    month_names:
+    -
+    - Januar
+    - Februar
+    - März
+    - April
+    - Mai
+    - Juni
+    - Juli
+    - August
+    - September
+    - Oktober
+    - November
+    - Dezember
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: etwa eine Stunde
+        other: etwa %{count} Stunden
+      about_x_months:
+        one: etwa ein Monat
+        other: etwa %{count} Monate
+      about_x_years:
+        one: etwa ein Jahr
+        other: etwa %{count} Jahre
+      almost_x_years:
+        one: fast ein Jahr
+        other: fast %{count} Jahre
+      half_a_minute: eine halbe Minute
+      less_than_x_seconds:
+        one: weniger als eine Sekunde
+        other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
+      over_x_years:
+        one: mehr als ein Jahr
+        other: mehr als %{count} Jahre
+      x_seconds:
+        one: eine Sekunde
+        other: "%{count} Sekunden"
+      x_minutes:
+        one: eine Minute
+        other: "%{count} Minuten"
+      x_days:
+        one: ein Tag
+        other: "%{count} Tage"
+      x_months:
+        one: ein Monat
+        other: "%{count} Monate"
+      x_years:
+        one: ein Jahr
+        other: "%{count} Jahre"
+    prompts:
+      second: Sekunde
+      minute: Minute
+      hour: Stunde
+      day: Tag
+      month: Monat
+      year: Jahr
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: muss akzeptiert werden
+      blank: muss ausgefüllt werden
+      confirmation: stimmt nicht mit %{attribute} überein
+      empty: muss ausgefüllt werden
+      equal_to: muss genau %{count} sein
+      even: muss gerade sein
+      exclusion: ist nicht verfügbar
+      greater_than: muss größer als %{count} sein
+      greater_than_or_equal_to: muss größer oder gleich %{count} sein
+      inclusion: ist kein gültiger Wert
+      invalid: ist nicht gültig
+      less_than: muss kleiner als %{count} sein
+      less_than_or_equal_to: muss kleiner oder gleich %{count} sein
+      model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      not_a_number: ist keine Zahl
+      not_an_integer: muss ganzzahlig sein
+      odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
+      taken: ist bereits vergeben
+      too_long:
+        one: ist zu lang (mehr als 1 Zeichen)
+        other: ist zu lang (mehr als %{count} Zeichen)
+      too_short:
+        one: ist zu kurz (weniger als 1 Zeichen)
+        other: ist zu kurz (weniger als %{count} Zeichen)
+      wrong_length:
+        one: hat die falsche Länge (muss genau 1 Zeichen haben)
+        other: hat die falsche Länge (muss genau %{count} Zeichen haben)
+    template:
+      body: 'Bitte überprüfen Sie die folgenden Felder:'
+      header:
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
+  helpers:
+    select:
+      prompt: Bitte wählen
+    submit:
+      create: "%{model} erstellen"
+      submit: "%{model} speichern"
+      update: "%{model} aktualisieren"
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " und "
+      two_words_connector: " und "
+      words_connector: ", "
+  time:
+    am: vormittags
+    formats:
+      default: "%A, %d. %B %Y, %H:%M Uhr"
+      long: "%A, %d. %B %Y, %H:%M Uhr"
+      short: "%d. %B, %H:%M Uhr"
+    pm: nachmittags
+  homepage:
+    title: "Community Photo-Sharing für Übergangsverfahren"
+    considering: "Denken Sie darüber nach oder hatten Sie eine Übergangspflege?"
+    join: "Sie sollten unserer Community beitreten."
+    register: "Registrieren Sie sich, um echte Ergebnisse zu teilen oder zu sehen."
+  header:
+    news: "Nachrichten"
+    procedures: "Auflistung der Verfahren"
+    surgeons: "Auflistung der Chirurgen"
+    submissions: "Einreichungen"
+    account: "Konto"
+  footer:
+    about: "über die Website"
+    tos: "Nutzungsbedingungen"
+    pp: "Datenschutz-Bestimmungen"
+  account_menu:
+    register: "Anmelden"
+    login: "Einloggen"
+    my_account: "Mein Konto"
+    logout: "Ausloggen"
+  explanations:
+    username: "Ihr Benutzername ist für alle Benutzer sichtbar und wird zum Anmelden verwendet. Er ist auf der gesamten Website eindeutig."
+    email: "Ihre E-Mail ist für Administratoren sichtbar, jedoch nicht für andere Benutzer. Ihre E-Mail wird bestätigt."
+    password: "Ihr Passwort wird beim Speichern verschlüsselt und kann per E-Mail wiederhergestellt werden."
+    name: "Ihr Name ist für Administratoren sichtbar und wird für die Kommunikation mit ihnen verwendet. Wenn Sie ein Pflegedienstleister sind und nicht Ihren richtigen Namen verwenden, werden Sie von der Website blockiert."
+    gender: "Ihr Geschlecht ist für alle sichtbar, wenn Sie Ergebnisse veröffentlichen. Es wird auch verwendet, um einige Standardeinstellungen für den angezeigten Inhalt und Ihre Pronomen festzulegen. Es kann nach der Registrierung aktualisiert werden."
+    tos: "Durch die Registrierung auf Transbucket.com erklären Sie sich mit unseren Nutzungsbedingungen einverstanden."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,30 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  homepage:
+    title: "Community Photo-Sharing for Transition Procedures"
+    considering: "Are you considering or have had transition care?"
+    join: "You should join our community."
+    register: "Register to share or see real results."
+  header:
+    news: "News"
+    procedures: "Procedures"
+    surgeons: "Surgeons"
+    submissions: "Submissions"
+    account: "Account"
+  footer:
+    about: "About"
+    tos: "Terms of Service"
+    pp: "Privacy Policy"
+  account_menu:
+    register: "Register"
+    login: "Login"
+    my_account: "My Account"
+    logout: "Logout"
+  explanations:
+    username: "Your username will be visible to all users and is what you use to log in. It is unique across the site."
+    email: "Your email will be visible to admins but not other users. Your email will be confirmed."
+    password: "Your password will be encrypted when stored, and can be recovered using your email."
+    name: "Your name will be visible to admins and used in communications with them. If you are a care provider and do not use your real name, you will be blocked from the site."
+    gender: "Your gender will be visible to everyone when you post results. It is also used to set some defaults for what content you see and your pronouns. It can be updated after registration."
+    tos: "By registering on Transbucket.com you agree to follow our Terms of Service."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,9 @@ en:
     surgeons: "Surgeons"
     submissions: "Submissions"
     account: "Account"
+    filter: "Filter"
+    add: "Add"
+    search: "Search"
   footer:
     about: "About"
     tos: "Terms of Service"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,246 @@
+---
+es:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validación falló: %{errors}'
+        restrict_dependent_destroy:
+          has_one: No se puede eliminar el registro porque existe un %{record} dependiente
+          has_many: No se puede eliminar el registro porque existen %{record} dependientes
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    -
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    -
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_years:
+        one: 1 año
+        other: "%{count} años"
+    prompts:
+      second: Segundo
+      minute: Minuto
+      hour: Hora
+      day: Día
+      month: Mes
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado
+      blank: no puede estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío
+      equal_to: debe ser igual a %{count}
+      even: debe ser par
+      exclusion: está reservado
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      model_invalid: 'La validación falló: %{errors}'
+      not_a_number: no es un número
+      not_an_integer: debe ser un entero
+      odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
+      required: debe existir
+      taken: ya está en uso
+      too_long:
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
+      too_short:
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
+      wrong_length:
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
+    template:
+      body: 'Se encontraron problemas con los siguientes campos:'
+      header:
+        one: No se pudo guardar este/a %{model} porque se encontró 1 error
+        other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
+    pm: pm
+  homepage:
+    title: "Uso compartido de fotografías en la comunidad para los procedimientos de transición"
+    considering: "¿Está considerando o ha recibido atención de transición?"
+    join: "Deberías unirte a nuestra comunidad."
+    register: "Regístrese para ver resultados reales."
+  header:
+    news: "Noticias"
+    procedures: "Procedimientos"
+    surgeons: "Cirujanos"
+    submissions: "Envios"
+    account: "Cuenta"
+  footer:
+    about: "Sobre el sitio"
+    tos: "Términos de servicio"
+    pp: "Política de privacidad"
+  account_menu:
+    register: "Registrarse"
+    login: "Iniciar sesión"
+    my_account: "Mi Cuenta"
+    logout: "Cerrar sesión"
+  explanations:
+    username: "Su nombre de usuario será visible para todos los usuarios y es lo que usa para iniciar sesión. Es único en todo el sitio."
+    email: "Su correo electrónico será visible para los administradores, pero no para otros usuarios. Se confirmará su correo electrónico."
+    password: "Su contraseña se cifrará cuando se almacene y se puede recuperar mediante su correo electrónico."
+    name: "Su nombre será visible para los administradores y se utilizará en las comunicaciones con ellos. Si usted es un proveedor de atención médica y no usa su nombre real, será bloqueado del sitio."
+    gender: "Su género será visible para todos cuando publique resultados. También se utiliza para establecer algunos valores predeterminados para el contenido que ve y sus pronombres. Puede actualizarse después del registro."
+    tos: "Al registrarse en Transbucket.com, acepta seguir nuestros Términos de servicio."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,246 @@
+---
+fr:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validation a échoué : %{errors}'
+        restrict_dependent_destroy:
+          has_one: Vous ne pouvez pas supprimer l'enregistrement car un(e) %{record}
+            dépendant(e) existe
+          has_many: Vous ne pouvez pas supprimer l'enregistrement parce que les %{record}
+            dépendants existent
+  date:
+    abbr_day_names:
+    - dim
+    - lun
+    - mar
+    - mer
+    - jeu
+    - ven
+    - sam
+    abbr_month_names:
+    - 
+    - jan.
+    - fév.
+    - mar.
+    - avr.
+    - mai
+    - juin
+    - juil.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
+    day_names:
+    - dimanche
+    - lundi
+    - mardi
+    - mercredi
+    - jeudi
+    - vendredi
+    - samedi
+    formats:
+      default: "%d/%m/%Y"
+      long: "%e %B %Y"
+      short: "%e %b"
+    month_names:
+    - 
+    - janvier
+    - février
+    - mars
+    - avril
+    - mai
+    - juin
+    - juillet
+    - août
+    - septembre
+    - octobre
+    - novembre
+    - décembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: environ une heure
+        other: environ %{count} heures
+      about_x_months:
+        one: environ un mois
+        other: environ %{count} mois
+      about_x_years:
+        one: environ un an
+        other: environ %{count} ans
+      almost_x_years:
+        one: presqu'un an
+        other: presque %{count} ans
+      half_a_minute: une demi‑minute
+      less_than_x_seconds:
+        zero: moins d'une seconde
+        one: moins d'une seconde
+        other: moins de %{count} secondes
+      less_than_x_minutes:
+        zero: moins d'une minute
+        one: moins d'une minute
+        other: moins de %{count} minutes
+      over_x_years:
+        one: plus d'un an
+        other: plus de %{count} ans
+      x_seconds:
+        one: 1 seconde
+        other: "%{count} secondes"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 jour
+        other: "%{count} jours"
+      x_months:
+        one: 1 mois
+        other: "%{count} mois"
+      x_years:
+        one: 1 an
+        other: "%{count} ans"
+    prompts:
+      second: Seconde
+      minute: Minute
+      hour: Heure
+      day: Jour
+      month: Mois
+      year: Année
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: doit être accepté(e)
+      blank: doit être rempli(e)
+      confirmation: ne concorde pas avec %{attribute}
+      empty: doit être rempli(e)
+      equal_to: doit être égal à %{count}
+      even: doit être pair
+      exclusion: n'est pas disponible
+      greater_than: doit être supérieur à %{count}
+      greater_than_or_equal_to: doit être supérieur ou égal à %{count}
+      inclusion: n'est pas inclus(e) dans la liste
+      invalid: n'est pas valide
+      less_than: doit être inférieur à %{count}
+      less_than_or_equal_to: doit être inférieur ou égal à %{count}
+      model_invalid: 'Validation échouée : %{errors}'
+      not_a_number: n'est pas un nombre
+      not_an_integer: doit être un nombre entier
+      odd: doit être impair
+      other_than: doit être différent de %{count}
+      present: doit être vide
+      required: doit exister
+      taken: n'est pas disponible
+      too_long:
+        one: est trop long (pas plus d'un caractère)
+        other: est trop long (pas plus de %{count} caractères)
+      too_short:
+        one: est trop court (au moins un caractère)
+        other: est trop court (au moins %{count} caractères)
+      wrong_length:
+        one: ne fait pas la bonne longueur (doit comporter un seul caractère)
+        other: ne fait pas la bonne longueur (doit comporter %{count} caractères)
+    template:
+      body: 'Veuillez vérifier les champs suivants : '
+      header:
+        one: 'Impossible d''enregistrer ce(tte) %{model} : 1 erreur'
+        other: 'Impossible d''enregistrer ce(tte) %{model} : %{count} erreurs'
+  helpers:
+    select:
+      prompt: Veuillez sélectionner
+    submit:
+      create: Créer un(e) %{model}
+      submit: Enregistrer ce(tte) %{model}
+      update: Modifier ce(tte) %{model}
+  number:
+    currency:
+      format:
+        delimiter: " "
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: " "
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: milliard
+          million: million
+          quadrillion: million de milliards
+          thousand: millier
+          trillion: billion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: octet
+            other: octets
+          eb: Eo
+          gb: Go
+          kb: ko
+          mb: Mo
+          pb: Po
+          tb: To
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " et "
+      two_words_connector: " et "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%d %B %Y %Hh %Mmin %Ss"
+      long: "%A %d %B %Y %Hh%M"
+      short: "%d %b %Hh%M"
+    pm: pm
+  homepage:
+    title: "Partage de photos avec la communauté pour les procédures de transition"
+    considering: "Envisagez-vous ou avez-vous reçu des soins de transition?"
+    join: "Vous devriez rejoindre notre communauté."
+    register: "Inscrivez-vous pour partager ou voir de vrais résultats."
+  header:
+    news: "Nouvelles"
+    procedures: "Procédures"
+    surgeons: "Chirurgiens"
+    submissions: "Soumissions"
+    account: "Compte"
+  footer:
+    about: "À propos du site"
+    tos: "Conditions d'utilisation"
+    pp: "Politique de confidentialité"
+  account_menu:
+    register: "S'inscrire"
+    login: "Connexion"
+    my_account: "Mon compte"
+    logout: "Se déconnecter"
+  explanations:
+    username: "Votre nom d'utilisateur sera visible par tous les utilisateurs et c'est ce que vous utilisez pour vous connecter. Il est unique sur le site."
+    email: "Votre e-mail sera visible par les administrateurs, mais pas par les autres utilisateurs. Votre email sera confirmé."
+    password: "Votre mot de passe sera crypté lors de son stockage et peut être récupéré à l'aide de votre e-mail."
+    name: "Votre nom sera visible par les administrateurs et utilisé dans les communications avec eux. Si vous êtes un prestataire de soins et que vous n'utilisez pas votre vrai nom, vous serez bloqué sur le site."
+    gender: "Votre sexe sera visible par tous lorsque vous publierez des résultats. Il est également utilisé pour définir des valeurs par défaut pour le contenu que vous voyez et vos pronoms. Il peut être mis à jour après l'enregistrement."
+    tos: "En vous inscrivant sur Transbucket.com, vous acceptez de suivre nos conditions d'utilisation."

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,241 @@
+---
+it:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validazione fallita: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Il record non può essere cancellato perchè esiste un %{record}
+            dipendente
+          has_many: Il record non può essere cancellato perchè esistono %{record}
+            dipendenti
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mer
+    - gio
+    - ven
+    - sab
+    abbr_month_names:
+    - 
+    - gen
+    - feb
+    - mar
+    - apr
+    - mag
+    - giu
+    - lug
+    - ago
+    - set
+    - ott
+    - nov
+    - dic
+    day_names:
+    - domenica
+    - lunedì
+    - martedì
+    - mercoledì
+    - giovedì
+    - venerdì
+    - sabato
+    formats:
+      default: "%d/%m/%Y"
+      long: "%d %B %Y"
+      short: "%d %b"
+    month_names:
+    - 
+    - gennaio
+    - febbraio
+    - marzo
+    - aprile
+    - maggio
+    - giugno
+    - luglio
+    - agosto
+    - settembre
+    - ottobre
+    - novembre
+    - dicembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: circa un'ora
+        other: circa %{count} ore
+      about_x_months:
+        one: circa un mese
+        other: circa %{count} mesi
+      about_x_years:
+        one: circa un anno
+        other: circa %{count} anni
+      almost_x_years:
+        one: circa 1 anno
+        other: circa %{count} anni
+      half_a_minute: mezzo minuto
+      less_than_x_seconds:
+        one: meno di un secondo
+        other: meno di %{count} secondi
+      less_than_x_minutes:
+        one: meno di un minuto
+        other: meno di %{count} minuti
+      over_x_years:
+        one: oltre un anno
+        other: oltre %{count} anni
+      x_seconds:
+        one: 1 secondo
+        other: "%{count} secondi"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minuti"
+      x_days:
+        one: 1 giorno
+        other: "%{count} giorni"
+      x_months:
+        one: 1 mese
+        other: "%{count} mesi"
+      x_years:
+        one: 1 anno
+        other: "%{count} anni"
+    prompts:
+      second: Secondi
+      minute: Minuto
+      hour: Ora
+      day: Giorno
+      month: Mese
+      year: Anno
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: deve essere accettata
+      blank: non può essere lasciato in bianco
+      confirmation: non coincide con %{attribute}
+      empty: non può essere vuoto
+      equal_to: deve essere uguale a %{count}
+      even: deve essere pari
+      exclusion: è riservato
+      greater_than: deve essere maggiore di %{count}
+      greater_than_or_equal_to: deve essere maggiore o uguale a %{count}
+      inclusion: non è compreso tra le opzioni disponibili
+      invalid: non è valido
+      less_than: deve essere minore di %{count}
+      less_than_or_equal_to: deve essere minore o uguale a %{count}
+      not_a_number: non è un numero
+      not_an_integer: non è un numero intero
+      odd: deve essere dispari
+      other_than: devono essere di numero diverso da %{count}
+      present: deve essere lasciato in bianco
+      required: deve esistere
+      taken: è già presente
+      too_long:
+        one: è troppo lungo (il massimo è 1 carattere)
+        other: è troppo lungo (il massimo è %{count} caratteri)
+      too_short:
+        one: è troppo corto (il minimo è 1 carattere)
+        other: è troppo corto (il minimo è %{count} caratteri)
+      wrong_length:
+        one: è della lunghezza sbagliata (deve essere di 1 carattere)
+        other: è della lunghezza sbagliata (deve essere di %{count} caratteri)
+    template:
+      body: 'Ricontrolla i seguenti campi:'
+      header:
+        one: 'Non posso salvare questo %{model}: 1 errore'
+        other: 'Non posso salvare questo %{model}: %{count} errori.'
+  helpers:
+    select:
+      prompt: Seleziona...
+    submit:
+      create: Crea %{model}
+      submit: Invia %{model}
+      update: Aggiorna %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 2
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Miliardi
+          million: Milioni
+          quadrillion: Biliardi
+          thousand: Mila
+          trillion: Bilioni
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Byte
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " e "
+      two_words_connector: " e "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a %d %b %Y, %H:%M:%S %z"
+      long: "%d %B %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm
+  homepage:
+    title: "Condivisione di foto della comunità per le procedure di transizione"
+    considering: "Stai considerando o hai ricevuto cure di transizione?"
+    join: "Dovresti unirti alla nostra comunità."
+    register: "Registrati per condividere o vedere risultati reali."
+  header:
+    news: "Notizia"
+    procedures: "Procedure"
+    surgeons: "Chirurghi"
+    submissions: "Presentazioni"
+    account: "Account"
+  footer:
+    about: "Informazioni sul sito"
+    tos: "Termini di servizio"
+    pp: "Politica sulla riservatezza"
+  account_menu:
+    register: "Registrati"
+    login: "Login"
+    my_account: "Il mio account"
+    logout: "Disconnettersi"
+  explanations:
+    username: "Il tuo nome utente sarà visibile a tutti gli utenti ed è ciò che utilizzi per accedere. È unico in tutto il sito."
+    email: "La tua email sarà visibile agli amministratori ma non agli altri utenti. La tua email sarà confermata."
+    password: "La password verrà crittografata una volta archiviata e potrà essere recuperata utilizzando la posta elettronica."
+    name: "Il tuo nome sarà visibile agli amministratori e utilizzato nelle comunicazioni con loro. Se sei un fornitore di cure e non usi il tuo vero nome, sarai bloccato dal sito."
+    gender: "Il tuo sesso sarà visibile a tutti quando pubblichi i risultati. Viene anche utilizzato per impostare alcuni valori predefiniti per il contenuto che vedi e per i tuoi pronomi. Può essere aggiornato dopo la registrazione."
+    tos: "Registrandoti su Transbucket.com accetti di seguire i nostri Termini di servizio."

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,227 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後
+  homepage:
+    title: "移行手順のためのコミュニティ写真共有"
+    considering: "移行ケアを検討していますか、それとも受けましたか？"
+    join: "あなたは私たちのコミュニティに参加する必要があります。"
+    register: "実際の結果を確認するには、登録してください。"
+  header:
+    news: "ニュース"
+    procedures: "手順"
+    surgeons: "外科医"
+    submissions: "提出物"
+    account: "アカウント"
+  footer:
+    about: "ウェブサイトについて"
+    tos: "利用規約"
+    pp: "個人情報保護方針"
+  account_menu:
+    register: "サインアップ"
+    login: "ログインする"
+    my_account: "マイアカウント"
+    logout: "ログアウト"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,208 @@
+---
+zh-CN:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: '验证失败: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 由于 %{record} 需要此记录，所以无法移除记录
+          has_many: 由于 %{record} 需要此记录，所以无法移除记录
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    -
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 大约 %{count} 小时
+      about_x_months: 大约 %{count} 个月
+      about_x_years: 大约 %{count} 年
+      almost_x_years: 接近 %{count} 年
+      half_a_minute: 半分钟
+      less_than_x_seconds: 不到 %{count} 秒
+      less_than_x_minutes: 不到 %{count} 分钟
+      over_x_years: "%{count} 年多"
+      x_seconds: "%{count} 秒"
+      x_minutes: "%{count} 分钟"
+      x_days: "%{count} 天"
+      x_months: "%{count} 个月"
+      x_years: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 时
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: 必须是可被接受的
+      blank: 不能为空字符
+      confirmation: 与 %{attribute} 不匹配
+      empty: 不能留空
+      equal_to: 必须等于 %{count}
+      even: 必须为双数
+      exclusion: 是保留关键字
+      greater_than: 必须大于 %{count}
+      greater_than_or_equal_to: 必须大于或等于 %{count}
+      inclusion: 不包含于列表中
+      invalid: 是无效的
+      less_than: 必须小于 %{count}
+      less_than_or_equal_to: 必须小于或等于 %{count}
+      model_invalid: '验证失败: %{errors}'
+      not_a_number: 不是数字
+      not_an_integer: 必须是整数
+      odd: 必须为单数
+      other_than: 长度非法（不可为 %{count} 个字符
+      present: 必须是空白
+      required: 必须存在
+      taken: 已经被使用
+      too_long: 过长（最长为 %{count} 个字符）
+      too_short: 过短（最短为 %{count} 个字符）
+      wrong_length: 长度非法（必须为 %{count} 个字符）
+    template:
+      body: 如下字段出现错误：
+      header: 有 %{count} 个错误发生导致“%{model}”无法被保存。
+  helpers:
+    select:
+      prompt: 请选择
+    submit:
+      create: 新增%{model}
+      submit: 储存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u %n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: CN¥
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十亿
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte: 字节
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " 以及 "
+      two_words_connector: " 和 "
+      words_connector: "、"
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午
+  homepage:
+    title: "社区照片共享以实现过渡程序"
+    considering: "您是否正在考虑或已接受过渡护理？"
+    join: "您应该加入我们的社区"
+    register: "注册以分享或查看真实结果。"
+  header:
+    news: "消息"
+    procedures: "程序"
+    surgeons: "外科医生"
+    submissions: "意见书"
+    account: "帐户"
+  footer:
+    about: "关于这个网站"
+    tos: "服务条款"
+    pp: "隐私政策"
+  account_menu:
+    register: "登记"
+    login: "登录"
+    my_account: "我的帐户"
+    logout: "登出"
+  explanations:
+    username: "您的用户名将对所有用户可见，并且是您用来登录的用户名。在整个站点中，用户名是唯一的。"
+    email: "您的电子邮件对管理员可见，但对其他用户不可见。您的电子邮件将被确认。"
+    password: "您的密码在存储时将被加密，并可使用您的电子邮件进行恢复。"
+    name: "您的姓名将对管理员可见，并用于与他们的通讯中。如果您是护理提供者并且不使用您的真实姓名，那么您将被屏蔽。"
+    gender: "发布结果后，所有人都可以看到您的性别。它还用于为您看到的内容和代词设置一些默认值。注册后可以更新。"
+    tos: "通过在Transbucket.com上注册，您同意遵守我们的服务条款。"

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -1,0 +1,240 @@
+---
+zh-TW:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: '校驗失敗: %{errors}'
+        restrict_dependent_destroy:
+          has_one: 由於 %{record} 需要此記錄，所以無法移除記錄
+          has_many: 由於 %{record} 需要此記錄，所以無法移除記錄
+  date:
+    abbr_day_names:
+    - 周日
+    - 周一
+    - 周二
+    - 周三
+    - 周四
+    - 周五
+    - 周六
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 星期日
+    - 星期一
+    - 星期二
+    - 星期三
+    - 星期四
+    - 星期五
+    - 星期六
+    formats:
+      default: "%Y-%m-%d"
+      long: "%Y年%m月%d日"
+      short: "%m月%d日"
+    month_names:
+    -
+    - 一月
+    - 二月
+    - 三月
+    - 四月
+    - 五月
+    - 六月
+    - 七月
+    - 八月
+    - 九月
+    - 十月
+    - 十一月
+    - 十二月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 大約一小時
+        other: 大約 %{count} 小時
+      about_x_months:
+        one: 大約一個月
+        other: 大約 %{count} 個月
+      about_x_years:
+        one: 大約一年
+        other: 大約 %{count} 年
+      almost_x_years:
+        one: 接近一年
+        other: 接近 %{count} 年
+      half_a_minute: 半分鐘
+      less_than_x_seconds:
+        one: 不到一秒
+        other: 不到 %{count} 秒
+      less_than_x_minutes:
+        one: 不到一分鐘
+        other: 不到 %{count} 分鐘
+      over_x_years:
+        one: 一年多
+        other: "%{count} 年多"
+      x_seconds:
+        one: 一秒
+        other: "%{count} 秒"
+      x_minutes:
+        one: 一分鐘
+        other: "%{count} 分鐘"
+      x_days:
+        one: 一天
+        other: "%{count} 天"
+      x_months:
+        one: 一個月
+        other: "%{count} 個月"
+      x_years:
+        one: 一年
+        other: "%{count} 年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: 必須是可被接受的
+      blank: 不能為空白
+      confirmation: 與 %{attribute} 須一致
+      empty: 不能留空
+      equal_to: 必須等於 %{count}
+      even: 必須是偶數
+      exclusion: 是被保留的關鍵字
+      greater_than: 必須大於 %{count}
+      greater_than_or_equal_to: 必須大於或等於 %{count}
+      inclusion: 沒有包含在列表中
+      invalid: 是無效的
+      less_than: 必須小於 %{count}
+      less_than_or_equal_to: 必須小於或等於 %{count}
+      model_invalid: '校驗失敗: %{errors}'
+      not_a_number: 不是數字
+      not_an_integer: 必須是整數
+      odd: 必須是奇數
+      other_than: 不可以是 %{count} 個字
+      present: 必須是空白
+      required: 必須存在
+      taken: 已經被使用
+      too_long:
+        one: 過長（最長是一個字）
+        other: 過長（最長是 %{count} 個字）
+      too_short:
+        one: 過短（最短是一個字）
+        other: 過短（最短是 %{count} 個字）
+      wrong_length:
+        one: 字數錯誤 (必須是一個字)
+        other: 字數錯誤 (必須是 %{count} 個字)
+    template:
+      body: 以下欄位發生問題：
+      header:
+        one: 有 1 個錯誤發生使得「%{model}」無法被儲存。
+        other: 有 %{count} 個錯誤發生使得「%{model}」無法被儲存。
+  helpers:
+    select:
+      prompt: 請選擇
+    submit:
+      create: 新增%{model}
+      submit: 儲存%{model}
+      update: 更新%{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: NT$
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百萬
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: false
+        strip_insignificant_zeros: false
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: 位元組
+            other: 位元組
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", 和 "
+      two_words_connector: " 和 "
+      words_connector: ", "
+  time:
+    am: 上午
+    formats:
+      default: "%Y年%m月%d日 %A %H:%M:%S %Z"
+      long: "%Y年%m月%d日 %H:%M"
+      short: "%m月%d日 %H:%M"
+    pm: 下午
+  homepage:
+    title: "社區照片共享以實現過渡程序"
+    considering: "您是否正在考慮或已接受過渡護理？"
+    join: "您應該加入我們的社區。"
+    register: "註冊以分享或查看真實結果。"
+  header:
+    news: "消息"
+    procedures: "程序"
+    surgeons: "外科醫生"
+    submissions: "意見書"
+    account: "帳戶"
+  footer:
+    about: "關於網站"
+    tos: "服務條款"
+    pp: "隱私政策"
+  account_menu:
+    register: "注冊"
+    login: "登錄"
+    my_account: "我的帳戶"
+    logout: "登出"
+  explanations:
+    username: "您的用戶名將對所有用戶可見，並且是您用來登錄的用戶名。在整個站點中，用戶名是唯一的。"
+    email: "您的電子郵件對管理員可見，但對其他用戶不可見。您的電子郵件將被確認。"
+    password: "您的密碼在存儲時將被加密，並可使用您的電子郵件進行恢復。"
+    name: "您的姓名將對管理員可見，並用於與他們的通訊中。如果您是護理提供者並且不使用您的真實姓名，那麼您將被屏蔽。"
+    gender: "發布結果後，所有人都可以看到您的性別。它還用於為您看到的內容和代詞設置一些默認值。註冊後可以更新。"
+    tos: "通過在Transbucket.com上註冊，您同意遵守我們的服務條款。"

--- a/spec/features/password_reset_spec.rb
+++ b/spec/features/password_reset_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "password reset" do
     new_password = Faker::Internet.password
 
     fill_in "New password", :with => new_password
-    fill_in "New password confirmation", :with => new_password
+    fill_in "Confirm new password", :with => new_password
     click_button "Change my password"
 
     expect(page).to have_content("Your password was changed successfully.")

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "registration" do
   shared_examples "registration" do
     it "displays errors upon incorrect input" do
       self.send(:fill_out_sign_up, user, invalid: true)
-      click_button "Submit"
+      click_button "Sign up"
       expect(page).to have_content("Email can't be blank")
     end
 
@@ -35,7 +35,7 @@ RSpec.describe "registration" do
 
       clear_emails
 
-      click_button "Submit"
+      click_button "Sign up"
 
       expect(page).to have_content("A message with a confirmation link")
 

--- a/spec/models/surgeon_spec.rb
+++ b/spec/models/surgeon_spec.rb
@@ -38,7 +38,7 @@ describe Surgeon do
   describe ".names" do
     it 'provides a list of names formatted for SearchController' do
       surgeons = create_list(:surgeon, 2)
-      name_string = "#{surgeons[0].last_name},#{surgeons[0].first_name}"
+      name_string = "#{surgeons[0].last_name}, #{surgeons[0].first_name}"
       expect(Surgeon.names).to include(name_string)
     end
   end


### PR DESCRIPTION
`devise_i18n` give us a lot of locales for free. I tested this using a [headers setting extension for Chrome](https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=en) and editing `Accept-Language`. But some pages, like the sign up page, are still pretty sparse.

The branch is up [on staging now](https://transbucket-staging.herokuapp.com/users/sign_in).

I also incidentally updated capybara (no help to spec stability sadly) and many of the forms switched from `form_for` to `simple_form_for` and I am not certain the error handling is great.

# screenshots of `zh`

(note I fixed "remember me" see comments further down)

![zh4](https://user-images.githubusercontent.com/1695630/109251456-89d49e80-77b9-11eb-98b3-464405a306f1.png)
![zh3](https://user-images.githubusercontent.com/1695630/109251458-8a6d3500-77b9-11eb-9e08-eecbc1ba83cc.png)
![zh2](https://user-images.githubusercontent.com/1695630/109251460-8a6d3500-77b9-11eb-876c-363991b7fb5a.png)
![zh1](https://user-images.githubusercontent.com/1695630/109251461-8a6d3500-77b9-11eb-9ff3-53f87e1cc7ce.png)
