### PR TITLE
SearchSchema - clean up for aggs, default to updated_at

### DIFF
--- a/app/presenters/pin_presenter.rb
+++ b/app/presenters/pin_presenter.rb
@@ -11,7 +11,7 @@ class PinPresenter
 
     @pins = if @query.present?
               # FIXME: with all includes get some unused eager, without get N+1
-              options = { sort: [{ updated_at: 'desc' }]}
+              options = { sort: [{ updated_at: {order: 'desc'}}]}
               Pin.search(@query, options).paginate(:page => @page).records
             elsif @user.present?
               Pin.includes(:user, :pin_images, :procedure, :surgeon).by_user(@user).paginate(:page => @page)

--- a/app/views/pins/_pin.html.erb
+++ b/app/views/pins/_pin.html.erb
@@ -45,7 +45,7 @@
       <!-- end if pin pending -->
       <% end %>
       <!-- end if user can edit -->
-        posted <%= distance_of_time_in_words(Time.now, pin.created_at) %> ago
+        updated <%= distance_of_time_in_words(Time.now, pin.updated_at) %> ago
       </div>
       <!-- end footer actions -->
     </div>

--- a/app/views/pins/index.html.erb
+++ b/app/views/pins/index.html.erb
@@ -1,8 +1,8 @@
 <%= javascript_include_tag "pins" %>
 <% if params[:query].present? %>
-<% title 'Search Result for ' + params[:query].titleize %>
+  <% title 'Search Result for ' + params[:query].titleize %>
 <% else %>
-<% title 'Recent Submissions' %>
+  <% title 'Recent Submissions' %>
 <% end %>
 <div id="pins">
   <%= render @presenter.pins %>


### PR DESCRIPTION
Will need to reindex using:

```
rake environment elasticsearch:import:all FORCE=y
```

Some queries we'll be able to do after:

```
GET development_pins/_search?size=0
{
  "query": {
    "terms": { "surgeon.pretty_name.keyword": [ "Abrikosovsky, Ruben" ] }
  },
  "aggregations": {
    "significant_x": {
      "significant_terms": { "field": "complications.name.keyword" }
    }
  }
}

GET development_pins/_search
{
  "query": {
    "match": {
      "complications.name": "stuffs"
    }
  }
}

GET development_pins/_search?size=0
{
  "aggs": {
    "test": {
      "terms": { "field": "complications.name.keyword" } 
    }
  }
}
```