### PR TITLE
Change wording to avoid ambiguous pronouns

### DIFF
--- a/app/views/pins/show.html.erb
+++ b/app/views/pins/show.html.erb
@@ -86,7 +86,7 @@
 <div id="comments-container">
   <h4><%= fa_icon("comments-o") %> discussion</h4>
   <%= render :partial => 'comments/comment', :collection => @comments, :as => :comment %>
-    <h5>Please respect pronouns when writing to the submission author. Their preferred pronouns are: <%= uses_pronouns(@pin.user.try(:gender)) %>.</h5>
+    <h5>Please respect pronouns when writing to the submission author. The author's preferred pronouns are: <%= uses_pronouns(@pin.user.try(:gender)) %>.</h5>
   <%= link_to "<h5>#{fa_icon("comments-o")} add thread</h5>".html_safe, new_comment_path(commentable_id: @pin.id, commentable_type: "Pin"), remote: true %>
   <div id="commentable" class="reply-target">
   </div>


### PR DESCRIPTION
A user pointed out that it's weird to immediately use the wrong pronouns for a user, so I thought it'd be nice to avoid ambiguity.

Old screenshot:

![image](https://user-images.githubusercontent.com/12358765/110505312-075ab180-80cc-11eb-897e-3068f27e797d.png)
