### PR TITLE
Update paperclip version and CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
       - run: bundle -v
       - ruby/bundle-install
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_cluster/settings -d '{ "transient": { "cluster.routing.allocation.disk.threshold_enabled": false } }'
       - run: bundle exec rake db:create
       - run: bundle exec rake db:migrate
-      - run: bundle exec rspec
+      - run: bundle exec rspec || bundle exec rspec --only-failures || bundle exec rspec --only-failures
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,75 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2 
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.3.3-node-browsers
+        environment:
+          RAILS_ENV: development
+    executor: ruby/default
+    steps:
+      - checkout
+      - run: bundle -v
+      - ruby/bundle-install
+      - save_cache:
+          key: gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+  test:
+    docker:
+      - image: circleci/ruby:2.3.3-node-browsers
+        environment:
+          POSTGRES_USER: postgres
+          RAILS_ENV: test
+          TEST_DB: circle_test
+          PHANTOM_JS: phantomjs-2.1.1-linux-x86_64
+      - image: circleci/postgres:9.6-alpine
+        environment:
+          POSTGRES_USER: postgres
+      - image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
+        environment:
+          cluster.name: transbucket-test
+          xpack.security.enabled: false
+          transport.host: localhost
+          network.host: 127.0.0.1
+          http.port: 9200
+          discovery.type: single-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
+      - run: sudo apt-get update
+      - run: sudo apt-get install libfontconfig1
+      - run: wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+      - run: tar -xjf $PHANTOM_JS.tar.bz2
+      - run: sudo mv $PHANTOM_JS /usr/local/share
+      - run: sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+      - run: bundle -v
+      - ruby/bundle-install
+      - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
+          name: Wait for elasticsearch
+          command: dockerize -wait tcp://localhost:9200 -timeout 1m
+      - run:
+          name: Lift elasticsearch disk watermark restrictions
+          command: |
+            curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_cluster/settings -d '{ "transient": { "cluster.routing.allocation.disk.threshold_enabled": false } }'
+      - run: bundle exec rake db:create
+      - run: bundle exec rake db:migrate
+      - run: bundle exec rspec
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - build
+    - test:
+        requires:
+          - build

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'active_model_serializers'
 gem 'pg'
 gem 'delayed_job_active_record'
 
-gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'
+gem 'paperclip', '~> 5.0.0'
 gem 'aws-sdk'
 
 # for slug ids

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/thoughtbot/paperclip
-  revision: 523bd46c768226893f23889079a7aa9c73b57d68
-  ref: 523bd46c768226893f23889079a7aa9c73b57d68
-  specs:
-    paperclip (4.3.1)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      cocaine (~> 0.5.5)
-      mime-types
-      mimemagic (= 0.3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -114,8 +102,7 @@ GEM
     capybara-email (2.5.0)
       capybara (~> 2.4)
       mail
-    climate_control (0.0.3)
-      activesupport (>= 3.0)
+    climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -264,7 +251,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.0)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.3)
@@ -279,6 +268,12 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    paperclip (5.0.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (~> 0.3.0)
     parallel (1.9.0)
     parallel_tests (2.5.0)
       parallel
@@ -531,7 +526,7 @@ DEPENDENCIES
   meta_request
   nested_form
   newrelic_rpm
-  paperclip!
+  paperclip (~> 5.0.0)
   parallel_tests
   pg
   phony_rails

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   host: localhost
   encoding: unicode
   pool: 5
-  username: Alex
+  username: <%= ENV['POSTGRES_USER'] || "Alex" %>
   password:
   morphology: stem_en
   enable_star: true
@@ -16,7 +16,7 @@ development:
 
 test:
   <<: *defaults
-  database: psql_test<%= ENV['TEST_ENV_NUMBER'] %>
+  database: <%= ENV['TEST_DB'] || ("psql_test" + (ENV['TEST_ENV_NUMBER'] || "")) %>
 
 production:
   <<: *defaults


### PR DESCRIPTION
This constrains the paperclip gem to a later version, so as to avoid the yanked dependency `mimemagic (= 0.3.0)`. It also updates the CircleCI config to use the version 2 syntax.