### PR TITLE
CommentMailerCleanup - distinguish between question and comment, unsu…

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,3 +1,4 @@
+# NOTE: this depends on delayed_jobs
 module NotificationsHelper
   def admin_review
     ReviewMailer.please_review(self)

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -1,9 +1,12 @@
 class CommentMailer < ActionMailer::Base
   default from: "admin@transbucket.com"
 
-  def new_comment_email(receiver_id, about_id)
+  def new_comment_email(receiver_id, about_id, question=false)
     @user = User.find(receiver_id)
-    @url  = 'http://www.transbucket.com/pins/' + about_id.to_s
-    mail(to: @user.email, subject: "Transbucket.com: New Comments on #{about_id}")
+    @url  = pin_url(id: about_id, host: "www.transbucket.com", protocol: :https)
+    @unsub  = edit_user_url(id: receiver_id, host: "www.transbucket.com", protocol: :https)
+    @comment_type = question ? "question" : "comment"
+    subject = "Transbucket.com: New #{@comment_type.titleize} on #{about_id}"
+    mail(to: @user.email, subject: subject)
   end
 end

--- a/app/views/comment_mailer/new_comment_email.html.erb
+++ b/app/views/comment_mailer/new_comment_email.html.erb
@@ -6,10 +6,15 @@
   <body>
     <h1>Hey, <%= @user.username %>!</h1>
     <p>
-      Another member has posted a comment on your submission.
+      Another member has posted a <%= @comment_type %> on your submission.
     </p>
     <p>
-      If you'd like to reply click <a href='<%= @url + "?utm_source=comment_reminder&utm_medium=email&utm_campaign=comment_reminder" %>'>this link</a>.
+      If you'd like to reply click <a href='<%= @url + "?utm_source=comment_reminder&utm_medium=email&utm_campaign=#{@comment_type}_reminder" %>'>this link</a>.</p>
+    <p>
+      If you have concerns about the content of what was commented on your post you can Flag it (3 Flags from different users will put it in review automatically) or if it is urgent, please email us for direct moderation.
     </p>
+    <p>
+      If you don't want to receive these notifications please edit your notification settings at <a href='<%= @unsub + "?utm_source=comment_reminder&utm_medium=email&utm_campaign=#{@comment_type}_reminder" %>'>this link</a>.</p>
+    <p>
   </body>
 </html>

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,18 +1,42 @@
 require 'rails_helper'
 
 describe CommentMailer do
-	let(:user) { create(:user) }
-	let(:commentable) { build(:pin, user: user) }
-	let(:body) {"all right"}
-	let(:mail) do
-		CommentMailer.new_comment_email(user.id, commentable.id)
-	end
-	it "should have the right subject line" do
-		expect(mail.subject).to eq("Transbucket.com: New Comments on #{commentable.id}")
-	end
-	it "should have the right url" do
-		comment_url = "http://www.transbucket.com/pins/#{commentable.id}" +
-			"?utm_source=comment_reminder&amp;utm_medium=email&amp;utm_campaign=comment_reminder"
-		expect(mail.body.raw_source).to include(comment_url)
-	end
+  let(:user) { create(:user) }
+  let(:commentable) { create(:pin, user: user) }
+  describe "comment doesn't contain question" do
+    let(:comment_mail) do
+      CommentMailer.new_comment_email(user.id, commentable.id)
+    end
+    it "should have the right subject line" do
+      expect(comment_mail.subject).to eq("Transbucket.com: New Comment on #{commentable.id}")
+    end
+    it "should have the right url" do
+      comment_url = "https://www.transbucket.com/pins/#{commentable.id}" +
+        "?utm_source=comment_reminder&amp;utm_medium=email&amp;utm_campaign=comment_reminder"
+        expect(comment_mail.body.raw_source).to include(comment_url)
+    end
+    it "should have the unsub url" do
+      comment_url = "https://www.transbucket.com/users/#{user.id}/edit" +
+        "?utm_source=comment_reminder&amp;utm_medium=email&amp;utm_campaign=comment_reminder"
+        expect(comment_mail.body.raw_source).to include(comment_url)
+    end
+  end
+  describe "comment contains a question" do
+    let(:question_mail) do
+      CommentMailer.new_comment_email(user.id, commentable.id, true)
+    end
+    it "should have the right subject line" do
+      expect(question_mail.subject).to eq("Transbucket.com: New Question on #{commentable.id}")
+    end
+    it "should have the right url" do
+      comment_url = "https://www.transbucket.com/pins/#{commentable.id}" +
+        "?utm_source=comment_reminder&amp;utm_medium=email&amp;utm_campaign=question_reminder"
+        expect(question_mail.body.raw_source).to include(comment_url)
+    end
+    it "should have the unsub url" do
+      comment_url = "https://www.transbucket.com/users/#{user.id}/edit" +
+        "?utm_source=comment_reminder&amp;utm_medium=email&amp;utm_campaign=question_reminder"
+        expect(question_mail.body.raw_source).to include(comment_url)
+    end
+  end
 end


### PR DESCRIPTION
I was just doing a bit of clean up here. Making sure the host points to https and then did a bit of refactoring to see if question vs comment matters to authors. The unsub link is important too.