### PR TITLE
Add a docker-compose.yml and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby:2.6.6
+
+RUN apt-get -yqq update && apt-get -yqq install nodejs postgresql-client
+
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get -yqq update && \
+    apt-get -yqq install google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome" && \
+    google-chrome --version
+
+RUN CHROME_VERSION="$(google-chrome --version)" \
+    && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
+    && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
+    && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
+    && cd /tmp \
+    && unzip chromedriver_linux64.zip \
+    && rm -rf chromedriver_linux64.zip \
+    && mv chromedriver /usr/local/bin/chromedriver \
+    && chmod +x /usr/local/bin/chromedriver \
+    && chromedriver --version
+
+WORKDIR /myapp
+COPY Gemfile /myapp/Gemfile
+COPY Gemfile.lock /myapp/Gemfile.lock
+RUN bundle install
+COPY . /myapp
+
+# Add a script to be executed every time the container starts.
+COPY entrypoint.sh /usr/bin/
+RUN chmod +x /usr/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+EXPOSE 3000
+
+# Start the main process.
+CMD ["bundle", "exec", "rails", "s", "-p", "3000", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ Elasticsearch for search.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 # setup
 
+## docker-compose
+
+Once you have [docker-compose](https://docs.docker.com/compose/install/)
+installed, you can spin up a containerized local dev environment by running:
+
+```sh
+docker-compose up --build
+```
+
+This will bring up the app at http://localhost:3000 alongside Elasticsearch,
+Kibana, and Postgres. You can then complete the initial setup by running:
+
+```sh
+docker-compose exec web bundle exec rake db:setup
+docker-compose exec web \
+    bundle exec rake environment elasticsearch:import:model CLASS=Pin INDEX=development_pins FORCE=y
+```
+
+To stop the environment, run:
+```sh
+docker-compose down
+```
+
+Alternatively, you can set up all the services directly on your machine as
+described in the rest of this section.
+
 ## database setup
 
 For set up, you'll need to make sure you have Elasticsearch installed for search functionality and Postgres installed for the actual database. The database is currently set up to have the user "Alex".

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,11 @@
 defaults: &defaults
   adapter: postgresql
   prepared_statements: false
-  host: localhost
+  host: <%= ENV['POSTGRES_HOST'] || "localhost" %>
   encoding: unicode
   pool: 5
   username: <%= ENV['POSTGRES_USER'] || "Alex" %>
-  password:
+  password: <%= ENV['POSTGRES_PASSWORD'] || "" %>
   morphology: stem_en
   enable_star: true
   min_infix_len: 3

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,5 +1,4 @@
 development: &default
-  host: 'http://localhost:9200'
   transport_options:
     request:
       timeout: !!integer 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+  db:
+    image: postgres
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+    networks:
+      - db
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
+    environment:
+      cluster.name: "docker-cluster"
+      discovery.type: single-node
+      cluster.routing.allocation.disk.threshold_enabled: "false"
+    ports:
+      - "9200:9200"
+    volumes:
+      - data01:/usr/share/elasticsearch_data
+    networks:
+      - elastic
+  kib01:
+    image: docker.elastic.co/kibana/kibana:7.11.1
+    container_name: kib01
+    ports:
+      - 5601:5601
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+    networks:
+      - elastic
+  web:
+    build: .
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    volumes:
+      - .:/myapp
+    networks:
+      - elastic
+    ports:
+      - "3000:3000"
+    environment:
+      BONSAI_URL: http://elasticsearch:9200
+      POSTGRES_HOST: db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    networks:
+      - db
+      - elastic
+    depends_on:
+      - db
+      - elasticsearch
+
+volumes:
+  data01:
+    driver: local
+
+networks:
+  db:
+    driver: bridge
+  elastic:
+    driver: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /myapp/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"


### PR DESCRIPTION
This facilitates a simple setup where one runs:

```
docker-compose up --build
```

and gets the full set of services (Elasticsearch, Postgres, Kibana,
Rails).

Note that Postgres is not open to the outside world, but Elasticsearch
and Kibana are available on http://localhost:9200 and
http://localhost:5601 -- this is to ease debugging. If you already have
these services running, you may wish to remove the port forwards from
docker-compose.yml.

To set up the Elasticsearch pin index for local development:

```
docker-compose exec web \
    bundle exec rake environment elasticsearch:import:model CLASS=Pin INDEX=development_pins FORCE=y
```

To shut down the servers, run:

```
docker-compose down
```

Test Plan:
- `docker-compose up --build`
- `docker-compose exec web bundle exec rake db:create db:setup`
- `docker-compose exec web bundle exec rspec`