### PR TITLE
NormalizeProcedures - enforces basic case insensitive uniqueness

### DIFF
--- a/app/forms/procedure_form.rb
+++ b/app/forms/procedure_form.rb
@@ -1,5 +1,13 @@
+require "reform/form/validation/unique_validator"
+
 class ProcedureForm < Reform::Form
   property :name
+  # NOTE: it shouldn't be required for usto repeat ourselves here but
+  # I couldn't get the recommended ways of sharing between the model
+  # and the form to work, documentation is from 2017 so...
+  # https://trailblazer.to/2.0/gems/reform/validation.html#unique-validation
+  validates :name, unique: { case_sensitive: false }
+
   property :gender
   property :body_type
   property :avg_sensation

--- a/app/forms/surgeon_form.rb
+++ b/app/forms/surgeon_form.rb
@@ -1,9 +1,12 @@
+require "reform/form/validation/unique_validator"
 class SurgeonForm < Reform::Form
   property :first_name
   validates :first_name, presence: true
 
   property :last_name
   validates :last_name, presence: true
+
+  validates :last_name, unique: { scope: [:first_name, :last_name] }
 
   property :address
   property :city

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -12,7 +12,12 @@ class Procedure < ActiveRecord::Base
 
   # attr_accessible :name, :body_type, :gender, :avg_sensation, :avg_satisfaction
 
-  validates :name, uniqueness: true
+  # all procedures are stored lowercase
+  before_save { self.name.downcase! }
+
+  # but when we validate the incoming record we compare case insensitive
+  # because we haven't downcased incoming string yet
+  validates :name, uniqueness: { case_sensitive: false }
   validates :name, presence: true
 
   def to_s

--- a/app/views/procedures/_procedure.html.erb
+++ b/app/views/procedures/_procedure.html.erb
@@ -1,5 +1,5 @@
 <tr itemscope itemtype="https://schema.org/MedicalProcedure">
-  <td><%= link_to procedure.name, procedure_path(procedure) %></td>
+  <td><%= link_to procedure.name.titleize, procedure_path(procedure) %></td>
   <% if user_signed_in? %>
   <td><%= link_to @pins_per_procedure[procedure.id] || 0, pins_path(procedure: procedure.id) %></td>
 <% else %>

--- a/spec/features/pin_creation_spec.rb
+++ b/spec/features/pin_creation_spec.rb
@@ -70,6 +70,16 @@ describe "pin creation" do
         check_pin_data(pin_data)
         check_photos(new_images)
       end
+
+      it "creates a pin, selecting a surgeon but duplicating a procedure" do
+        self.send(:pin_create)
+        select_in_field("pin_surgeon_attributes_id", surgeon.to_s, js: js)
+        add_procedure(procedure, js: js)
+
+        click_button "Submit Now"
+
+        expect(find("#error_explanation")).to have_content("Procedure name has already been taken")
+      end
     end
   end
 

--- a/spec/forms/procedure_form_spec.rb
+++ b/spec/forms/procedure_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'faker'
+
+describe "ProcedureForm" do
+  let(:procedure) { create(:procedure) }
+
+  context "validation" do
+    it "rejects when not unique name" do
+      procedure_form = ProcedureForm.new(Procedure.new)
+      expect(procedure_form.validate(procedure.attributes)).to be false
+    end
+    it "accepts when unique name" do
+      procedure_form = ProcedureForm.new(Procedure.new)
+      existing_procedure_attrs = procedure.attributes
+      existing_procedure_attrs[:name] = "Very Unique Name"
+      expect(procedure_form.validate(existing_procedure_attrs)).to be true
+    end
+  end
+end

--- a/spec/forms/surgeon_form_spec.rb
+++ b/spec/forms/surgeon_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'faker'
+
+describe "SurgeonForm" do
+  let(:surgeon) { create(:surgeon) }
+
+  context "validation" do
+    it "rejects when not unique first and last name" do
+      surgeon_form = SurgeonForm.new(Surgeon.new)
+      expect(surgeon_form.validate(surgeon.attributes)).to be false
+    end
+    it "accepts when same last name but different first name" do
+      surgeon_form = SurgeonForm.new(Surgeon.new)
+      unique_first_name_attrs = surgeon.attributes
+      unique_first_name_attrs[:first_name] = "Felix the Cat"
+      expect(surgeon_form.validate(unique_first_name_attrs)).to be true
+    end
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1,6 +1,27 @@
 require 'rails_helper'
 
 describe Procedure do
+  describe "normalization" do
+    it 'is stored lowercase' do
+      procedure = build(:procedure)
+      procedure.name = "Something We Know Is Capitalized"
+      procedure.save!
+      expect(procedure.name).to eq("something we know is capitalized")
+    end
+    it 'is unique irrespective of case' do
+      procedure = build(:procedure)
+      procedure.name = "Something We Know Is Capitalized"
+      procedure.save!
+      procedure2 = build(:procedure)
+      procedure2.name = "something we know is capitalized"
+      expect {
+        procedure2.save!
+      }.to raise_error(
+        ActiveRecord::RecordInvalid,
+        "Validation failed: Name has already been taken"
+      )
+    end
+  end
   describe "#recalculate_avgs" do
     it 'calculates avg sensation' do
       procedure = create(:procedure, :uncomputed)


### PR DESCRIPTION
There's a lot more that can be done to normalize procedures, mostly requiring some tree structuring to them and allowing 1:many on Pin:Procedure but this is the most basic start.