### PR TITLE
SearchTweaks - make search cross_fields AND for better relevance

### DIFF
--- a/app/presenters/pin_presenter.rb
+++ b/app/presenters/pin_presenter.rb
@@ -10,9 +10,9 @@ class PinPresenter
     @filter = opts
 
     @pins = if @query.present?
-              # FIXME: with all includes get some unused eager, without get N+1
-              options = { sort: [{ updated_at: {order: 'desc'}}]}
-              Pin.search(@query, options).paginate(:page => @page).records
+              # NOTE: could retry here with "or" but I think that is more confusing for users
+              search_results = Pin.search(PinSearchQuery.all_xfields(@query), PinSearchQuery::DEFAULT_OPTIONS)
+              search_results.paginate(page: @page).records
             elsif @user.present?
               Pin.includes(:user, :pin_images, :procedure, :surgeon).by_user(@user).paginate(:page => @page)
             elsif has_keywords?

--- a/app/queries/pin_search_query.rb
+++ b/app/queries/pin_search_query.rb
@@ -1,0 +1,27 @@
+class PinSearchQuery
+  DEFAULT_OPTIONS = { sort: [ { updated_at: { order: 'desc' } } ] }
+
+  # see Pin model for how the fields were indexed if you need to adjust the below
+  # also https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+  # https://github.com/elastic/elasticsearch-rails/tree/master/elasticsearch-model#searching
+  def self.all_xfields(search_terms, operator: "and")
+    return {
+      query:
+      { multi_match:
+        { query: search_terms,
+          fields: [
+            "surgeon.pretty_name",
+            "procedure.name",
+            "procedure.description",
+            "description",
+            "details",
+            "pin_images.caption",
+            "complications.name"
+          ],
+          type: "cross_fields",
+          operator: operator
+        }
+      }
+    }
+  end
+end

--- a/app/views/pins/index.html.erb
+++ b/app/views/pins/index.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_include_tag "pins" %>
 <% if params[:query].present? %>
-  <% title 'Search Result for ' + params[:query].titleize %>
+  <% title "Search Result for '#{params[:query]}'" %>
 <% else %>
   <% title 'Recent Submissions' %>
 <% end %>


### PR DESCRIPTION
This tweaks search so that results are more precise, rather than having the highest recall. I reason that _most_ users know to remove terms that decrease their recall.