### PR TITLE
Flag feedback

### DIFF
--- a/app/assets/javascripts/comments/flags.js
+++ b/app/assets/javascripts/comments/flags.js
@@ -1,9 +1,9 @@
 // FIXME: this is the bare minimum to give some feedback to users
 $(document).ready(function(){
   // on index page
-  $(".flag-pin").each(function(){
+  $(".flag-comment").each(function(){
     $(this).unbind().on('ajax:success', function(e, data, status, xhr){
-      var pinId = $(this).data('pin-id');
+      var commentId = $(this).data('comment-id');
 
       switch(data["status"]) {
         case "voted_down":
@@ -12,10 +12,10 @@ $(document).ready(function(){
           break;
         case "removed":
           // persists, item won't show up from server once in review
-          $('.item[data-pin-id="' + pinId + '"]').hide();
+          $('.comment[data-comment-id="' + commentId + '"]').hide();
           break;
         default:
-          console.log("unknown status reached while flagging " + pinId);
+          console.log("unknown status reached while flagging " + commentId);
       }
     }).on('ajax:error',function(e, xhr, status, error){
       console.log("error = " + JSON.stringify(error));
@@ -23,9 +23,9 @@ $(document).ready(function(){
   });
 
   // on admin page
-  $(".unflag-pin").each(function(){
+  $(".unflag-comment").each(function(){
     $(this).unbind().on('ajax:success', function(e, data, status, xhr){
-      var pinId = $(this).data('pin-id');
+      var commentId = $(this).data('comment-id');
 
       switch(data["status"]) {
         case "unflagged":
@@ -33,24 +33,23 @@ $(document).ready(function(){
           $(this).replaceWith('<i class="fa fa-check" aria-hidden="true"></i>');
           break;
         default:
-          console.log("unknown status reached while unflagging " + pinId);
+          console.log("unknown status reached while unflagging " + commentId);
       }
     }).on('ajax:error',function(e, xhr, status, error){
       console.log("error = " + JSON.stringify(error));
     });
   });
 
-  $(".delete-pin").each(function(){
+  $(".delete-comment").each(function(){
     $(this).unbind().on('ajax:success', function(e, data, status, xhr){
-      var pinId = $(this).data('pin-id');
-
+      var commentId = $(this).data('comment-id');
       switch(data["status"]) {
         case "destroyed":
           // persists, item won't show up from server once in review
-          $('.review-pin-row[data-pin-id="' + pinId + '"]').hide();
+          $('.review-comment-row[data-comment-id="' + commentId + '"]').hide();
           break;
         default:
-          console.log("unknown status reached while deleting " + pinId);
+          console.log("unknown status reached while deleting " + commentId);
       }
     }).on('ajax:error',function(e, xhr, status, error){
       console.log("error = " + JSON.stringify(error));

--- a/app/assets/javascripts/pins/flags.js
+++ b/app/assets/javascripts/pins/flags.js
@@ -1,0 +1,61 @@
+// FIXME: this is the bare minimum to give some feedback to users
+$(document).ready(function(){
+  // on index page
+  $(".flag-pin").each(function(){
+    $(this).unbind().on('ajax:success', function(e, data, status, xhr){
+      var pinId = $(this).attr('id').split("_")[0];
+
+      switch(data["status"]) {
+        case "voted_down":
+          // doesn't persist, but at least shows tapping it did something
+          $(this).replaceWith('<i class="fa fa-exclamation-circle" aria-hidden="true"></i>');
+          break;
+        case "removed":
+          // persists, item won't show up from server once in review
+          $('.item[data-pin-id="' + pinId + '"]').hide();
+          break;
+        default:
+          console.log("unknown status reached while flagging " + pinId);
+      }
+    }).on('ajax:error',function(e, xhr, status, error){
+      console.log("error = " + JSON.stringify(error));
+    });
+  });
+
+  // on admin page
+  $(".unflag-pin").each(function(){
+    $(this).unbind().on('ajax:success', function(e, data, status, xhr){
+      var pinId = $(this).attr('id').split("_")[0];
+
+      switch(data["status"]) {
+        case "unflagged":
+          // doesn't persist, but at least shows tapping it did something
+          $(this).replaceWith('<i class="fa fa-check" aria-hidden="true"></i>');
+          break;
+        default:
+          console.log("unknown status reached while unflagging " + pinId);
+      }
+    }).on('ajax:error',function(e, xhr, status, error){
+      console.log("e = " + JSON.stringify(e));
+      console.log("xhr = " + JSON.stringify(xhr));
+      console.log("status = " + JSON.stringify(status));
+      console.log("error = " + JSON.stringify(error));
+    });
+  });
+
+  $(".delete-pin").each(function(){
+    $(this).unbind().on('ajax:success', function(e, data, status, xhr){
+      var pinId = $(this).attr('id').split("_")[0];
+      switch(data["status"]) {
+        case "destroyed":
+          // persists, item won't show up from server once in review
+          $('.review-row[data-pin-id="' + pinId + '"]').hide();
+          break;
+        default:
+          console.log("unknown status reached while deleting " + pinId);
+      }
+    }).on('ajax:error',function(e, xhr, status, error){
+      console.log("error = " + JSON.stringify(error));
+    });
+  });
+});

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -34,7 +34,7 @@ class CommentsController < ApplicationController
   def destroy
     @comment = Comment.find(params[:id])
     if @comment.destroy
-      render :nothing => true, :status => :ok
+      render :json => {'status': 'destroyed'}, :status => :ok
     else
       render :json => @comment.errors, :status => :unprocessable_entity
     end

--- a/app/controllers/flags_controller.rb
+++ b/app/controllers/flags_controller.rb
@@ -11,9 +11,9 @@ class FlagsController < ApplicationController
     respond_to do |format|
       if @flag[:status].present?
         flash[:notice] = "Content flagged."
-        format.js { render json: @flag, status: :created }
+        format.json { render json: @flag, status: :created }
       else
-        format.js { render json: @flag.errors, status: :unprocessable_entity }
+        format.json { render json: @flag.errors, status: :unprocessable_entity }
       end
     end
   end
@@ -24,16 +24,16 @@ class FlagsController < ApplicationController
 
     @content = find_content(type, id)
     @content.votes.down.destroy_all
-    @content.publish!
+    publish_status = @content.publish!
 
     respond_to do |format|
-      if @content.published?
+      if publish_status
         flash[:notice] = "Removed flags."
+        format.json { render json: { status: 'unflagged'}, status: :ok }
       else
-        format.js {render json: @content, status: :unprocessable_entity }
+        format.json { render json: @content, status: :unprocessable_entity }
       end
     end
-
   end
 
   private

--- a/app/controllers/pins_controller.rb
+++ b/app/controllers/pins_controller.rb
@@ -91,8 +91,13 @@ class PinsController < ApplicationController
     @pin.destroy
 
     respond_to do |format|
-      format.html { redirect_to pins_url }
-      format.json { head :ok }
+      if Pin.find_by_id(@pin.id)
+        flash[:error] = "Could not destroy #{@pin.id}!"
+        format.json { render json: @pin.errors.full_messages, status: :unprocessable_entity }
+      else
+        flash[:notice] = "Destroyed #{@pin.id}"
+        format.json { render json: { status: 'destroyed' }, status: :ok }
+      end
     end
   end
 
@@ -134,7 +139,7 @@ class PinsController < ApplicationController
     params.require(:pin).permit!
     # FIXME: why was this commented out? should it be removed?
     # params.require(:pin).permit(:surgeon_id, :procedure_id, :cost, :revision, :details, :sensation, :satisfaction,
-                                # pin_images: [:photo, :caption])
+    # pin_images: [:photo, :caption])
   end
 
   def pin_index_params

--- a/app/presenters/pin_presenter.rb
+++ b/app/presenters/pin_presenter.rb
@@ -21,7 +21,7 @@ class PinPresenter
             else
               # NOTE: if we want to do by_user_gender, we'd do it here
               # but there's not an easy way to let people change this on the fly
-              Pin.includes(:user, :pin_images, :procedure, :surgeon).recent.paginate(:page => @page)
+              Pin.includes(:user).recent.paginate(:page => @page)
             end
   end
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if comment.published? %>
   <% cache(comment) do %>
-    <div class="comment" id="comment-<%=comment.id %>">
+    <div class="comment" id="comment-<%=comment.id %>" data-comment-id="<%= comment.id %>">
       <div class="panel panel-default">
         <div class="panel-body">
           <%= comment.body %>
@@ -14,7 +14,7 @@
             <% commentable = @pin ? @pin : @procedure %>
             <%= link_to "#{fa_icon("comments")} reply".html_safe, new_comment_path(commentable_id: commentable.try(:id), commentable_type: commentable.try(:class), parent_id: comment.id), remote: true %>
             <%= " | " unless current_user == comment.user %>
-            <%= link_to(fa_icon("flag"), comment_flags_path(comment), :method => :post, remote: true) unless current_user == comment.user %>
+            <%= link_to(fa_icon("flag"), comment_flags_path(comment), :method => :post, remote: true, class: "flag-comment", "data-comment-id" => comment.id) unless current_user == comment.user %>
           </small>
           <% if comment.user_id == current_user.id || current_user.admin? %>
             <%= link_to "×", comment_path(comment), :method => :delete, :remote => true, data: {confirm: "Are you sure you want to remove this comment?"}, :disable_with => "×", :class => 'close' %>

--- a/app/views/pins/_pin.html.erb
+++ b/app/views/pins/_pin.html.erb
@@ -34,7 +34,7 @@
     <div class="panel-footer">
       <div class="actions">
         <label class="label-with-popover" data-placement="right" data-content="Flags from 3 different users will remove content pending review by a moderator." data-title="Flag this content." data-trigger="hover">
-          <%= link_to(fa_icon("flag"), pin_flags_path(pin), :method => :post, remote: true) + " | " unless current_user == pin.user %>
+          <%= link_to(fa_icon("flag"), pin_flags_path(pin), method: :post, remote: true, id: "#{pin.id}_flag", class: "flag-pin") + " | " unless current_user == pin.user %>
         </label>
       <% if current_user == pin.user || current_user.admin? %>
         <%= link_to fa_icon("pencil-square-o"), edit_pin_path(pin) %>

--- a/app/views/pins/_pin.html.erb
+++ b/app/views/pins/_pin.html.erb
@@ -34,7 +34,7 @@
     <div class="panel-footer">
       <div class="actions">
         <label class="label-with-popover" data-placement="right" data-content="Flags from 3 different users will remove content pending review by a moderator." data-title="Flag this content." data-trigger="hover">
-          <%= link_to(fa_icon("flag"), pin_flags_path(pin), method: :post, remote: true, id: "#{pin.id}_flag", class: "flag-pin") + " | " unless current_user == pin.user %>
+          <%= link_to(fa_icon("flag"), pin_flags_path(pin), method: :post, remote: true, "data-pin-id" => pin.id, class: "flag-pin") + " | " unless current_user == pin.user %>
         </label>
       <% if current_user == pin.user || current_user.admin? %>
         <%= link_to fa_icon("pencil-square-o"), edit_pin_path(pin) %>

--- a/app/views/pins/admin.html.erb
+++ b/app/views/pins/admin.html.erb
@@ -2,7 +2,7 @@
 <h3><%= title 'Moderation Queue' %></h3>
 <div class="panel panel-default">
   <div class="panel-body">
-    <p>3 flags on a comment or pin land it in this queue. It is always possible users thought they were giving a thumbs up, so please make sure to check each pin or comment before deleting.</p>
+    <p>3 flags on a comment or pin land it in this queue. It is always possible users thought they were giving a thumbs up, so please make sure to check each pin or comment before deleting. Deletions prompt a confirmation, "unflagging" does not. This is because deletions can't be undone, but we can always send content back in for further review.</p>
     <p>Why is this page called "queendom"? Because hackers know to try and target any "admin/" or similar page. "queendom" is a partial anagram of moderation queue.</p>
   </div>
 </div>
@@ -15,11 +15,11 @@
   <th>delete</th>
   <% @queue[:pins].each do |e| %>
     <% user = User.find_by_id(e.user_id) || Struct::User.new("none", "deleted") %>
-    <tr class="review-row" data-pin-id=<%= e.id %>>
+    <tr class="review-pin-row" data-pin-id=<%= e.id %>>
       <td><%= link_to e.id, pin_path(e) %></td>
       <td><%= mail_to user.email, user.username %></td>
-      <td><%= link_to fa_icon("flag"), remove_pin_flag_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to republish this pin?", :disable_with => "unflag", id: "#{e.id}_unflag", class: "unflag-pin" %></td>
-      <td><%= link_to fa_icon("times"), pin_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to remove this pin?", :disable_with => "×", id: "#{e.id}_delete", class: "delete-pin" %></td></tr>
+      <td><%= link_to fa_icon("flag"), remove_pin_flag_path(e), :method => :delete, :remote => true, :data => { confirm: "Are you sure you want to remove this comment?" }, "data-pin-id" => e.id, class: "unflag-pin" %></td>
+      <td><%= link_to fa_icon("times"), pin_path(e), :method => :delete, :remote => true, :data => { confirm: "Are you sure you want to remove this comment?" }, "data-pin-id" => e.id, class: "delete-pin" %></td></tr>
   <% end %>
 </table>
 
@@ -34,11 +34,13 @@
   <% @queue[:comments].each do |e| %>
     <% user = User.find_by_id(e.user_id) || Struct::User.new("none", "deleted") %>
 
-    <tr><td><%= link_to e.id, pin_path(e.commentable_id) %> </td>
-      <td> <%= mail_to user.email, user.username %>
+    <tr class="review-comment-row" data-comment-id=<%= e.id %>>
+      <td><%= link_to e.id, pin_path(e.commentable_id) %></td>
+      <td><%= mail_to user.email, user.username %></td>
       <td><%= e.body %></td>
-      <td><%= link_to fa_icon("flag"), remove_comment_flag_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to republish this comment?", :disable_with => "unflag" %></td>
-      <td><%= link_to "×", comment_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to remove this comment?", :disable_with => "×"%></td></tr>
+      <td><%= link_to fa_icon("flag"), remove_comment_flag_path(e), :method => :delete, :remote => true, "data-comment-id" => e.id, :class => "unflag-comment" %></td>
+      <td><%= link_to fa_icon("times"), comment_path(e), :method => :delete, :remote => true, "data-comment-id" => e.id, :class => "delete-comment", :data => { confirm: "Are you sure you want to remove this comment?" } %></td>
+    </tr>
   <% end %>
 </table>
 

--- a/app/views/pins/admin.html.erb
+++ b/app/views/pins/admin.html.erb
@@ -15,10 +15,11 @@
   <th>delete</th>
   <% @queue[:pins].each do |e| %>
     <% user = User.find_by_id(e.user_id) || Struct::User.new("none", "deleted") %>
-    <tr><td><%= link_to e.id, pin_path(e) %> </td>
-      <td> <%= mail_to user.email, user.username %>
-      <td><%= link_to fa_icon("flag"), remove_pin_flag_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to republish this pin?", :disable_with => "unflag" %></td>
-      <td><%= link_to "×", pin_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to remove this pin?", :disable_with => "×"%></td></tr>
+    <tr class="review-row" data-pin-id=<%= e.id %>>
+      <td><%= link_to e.id, pin_path(e) %></td>
+      <td><%= mail_to user.email, user.username %></td>
+      <td><%= link_to fa_icon("flag"), remove_pin_flag_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to republish this pin?", :disable_with => "unflag", id: "#{e.id}_unflag", class: "unflag-pin" %></td>
+      <td><%= link_to fa_icon("times"), pin_path(e), :method => :delete, :remote => true, :confirm => "Are you sure you want to remove this pin?", :disable_with => "×", id: "#{e.id}_delete", class: "delete-pin" %></td></tr>
   <% end %>
 </table>
 


### PR DESCRIPTION
Something annoying over time as a mod is that the mod page didn't update in place, so when going through reviews it was easy to lose track of what was still there to review. Similarly, if a flag was clicked on a pin or comment by a user you really couldn't easily see anything happened. Now it will at least show a different icon if it incremented the vote, and if it removed the content for review that will happen without needing to reload the page.

This ! doesn't persist on reload, would have to actually connect it to the db to get that, but it's better than nothing.

![flag-fb](https://user-images.githubusercontent.com/1695630/113806451-4cf0b580-9730-11eb-96d3-d8f8817981e1.png)

The mod queue showing an unflag being checked off. Deletions now properly prompt a confirmation too.
![mod-q](https://user-images.githubusercontent.com/1695630/113806452-4d894c00-9730-11eb-9519-51f02b1aafea.png)