### PR TITLE
following heroku instructions, forcing ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
I'm not sure why post maintenance mode removal https forcing went away, I don't recall it being an issue before.

According to [heroku instructions](https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls) this should fix it for rails.