### PR TITLE
Fix local Docker dev environment for Ruby 3.1.6 / arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,22 @@
-FROM ruby:2.6.6
+FROM ruby:3.1.6
 
-RUN apt-get -yqq update && apt-get -yqq install nodejs postgresql-client
+# ruby:3.1.6 is based on Debian 12 (bookworm), which is still current, so no
+# archive.debian.org repointing is needed here (unlike the old ruby:2.6.6
+# image, which was based on the now-EOL Debian 10 buster).
+RUN apt-get -yqq update \
+    && apt-get -yqq install nodejs postgresql-client
 
-RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get -yqq update && \
-    apt-get -yqq install google-chrome-stable && \
-    rm -rf /var/lib/apt/lists/* && \
-    sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' "/opt/google/chrome/google-chrome" && \
-    google-chrome --version
-
-RUN CHROME_VERSION="$(google-chrome --version)" \
-    && export CHROMEDRIVER_RELEASE="$(echo $CHROME_VERSION | sed 's/^Google Chrome //')" && export CHROMEDRIVER_RELEASE=${CHROMEDRIVER_RELEASE%%.*} \
-    && CHROMEDRIVER_VERSION=$(curl --silent --show-error --location --fail --retry 4 --retry-delay 5 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROMEDRIVER_RELEASE}) \
-    && curl --silent --show-error --location --fail --retry 4 --retry-delay 5 --output /tmp/chromedriver_linux64.zip "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
-    && cd /tmp \
-    && unzip chromedriver_linux64.zip \
-    && rm -rf chromedriver_linux64.zip \
-    && mv chromedriver /usr/local/bin/chromedriver \
-    && chmod +x /usr/local/bin/chromedriver \
+# Chrome for Testing only publishes a linux64 (x86_64) chromedriver -- no
+# linux-arm64 build exists -- so pairing it with google-chrome-stable breaks
+# on arm64 hosts (e.g. Apple Silicon), where the browser installs natively
+# but the driver can only run under x86_64 emulation, which fails to find
+# its own dynamic linker in this image's arm64 rootfs. Installing chromium
+# and chromium-driver together from the same apt transaction gives a
+# natively-built, version-matched browser/driver pair on every architecture
+# this image supports, with no emulation involved.
+RUN apt-get -yqq install chromium chromium-driver \
+    && rm -rf /var/lib/apt/lists/* \
+    && chromium --version \
     && chromedriver --version
 
 WORKDIR /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ group :development do
   gem 'any_login'
 	gem 'letter_opener'
 	gem 'seed_dump'
-	gem 'thin', '~> 1.8'
 	gem 'quiet_assets'
 	gem 'better_errors'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,6 @@ GEM
     coolline (0.5.0)
       unicode_utils (~> 1.4)
     crass (1.0.7)
-    daemons (1.4.1)
     database_cleaner (1.5.3)
     date (3.5.1)
     declarative (0.0.7)
@@ -430,10 +429,6 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     stackprof (0.2.9)
-    thin (1.8.2)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (1.4.1)
@@ -548,7 +543,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   stackprof
-  thin (~> 1.8)
   tinymce-rails
   turbolinks
   uglifier (>= 1.0.3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres
+    image: postgres:13
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
     environment:

--- a/spec/support/capybara_config.rb
+++ b/spec/support/capybara_config.rb
@@ -3,8 +3,20 @@ require 'capybara/rspec'
 require 'capybara/email/rspec'
 
 Capybara.server = :webrick
-# remove _headless to actually see it manipulate chrome
-Capybara.javascript_driver = :selenium_chrome_headless
+
+# The Docker image runs everything as root, and Chromium refuses to use its
+# sandbox as root -- :selenium_chrome_headless doesn't pass --no-sandbox, so
+# register a driver that does. disable-dev-shm-usage avoids /dev/shm running
+# out of space in the container's default small shared-memory allocation.
+Capybara.register_driver :selenium_chrome_headless_docker do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(
+    args: %w[headless disable-gpu no-sandbox disable-dev-shm-usage]
+  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+# remove _headless_docker to actually see it manipulate chrome (outside Docker)
+Capybara.javascript_driver = :selenium_chrome_headless_docker
 Capybara.server_port = 9887 + ENV['TEST_ENV_NUMBER'].to_i
 ActionMailer::Base.default_url_options[:host] = "localhost:#{Capybara.server_port}"
 


### PR DESCRIPTION
## Summary

The Ruby 3.1.6 / Rails 4.2 migration (merged in `local/ruby-3-compat-audit`) left the local Docker dev setup broken: the Dockerfile's base image was never updated to match, and that mismatch masked a couple of other issues. This fixes `docker compose up` end-to-end on Apple Silicon.

- **Dockerfile**: `FROM ruby:2.6.6` → `ruby:3.1.6` (matches the Gemfile's required Ruby version; `bundle install` was failing on the mismatch). Dropped the now-unneeded `archive.debian.org` buster workaround (3.1.6's base image is bookworm, still current).
- **Dockerfile**: replaced `google-chrome-stable` + a manually downloaded linux64 (x86_64-only) Chrome-for-Testing `chromedriver` with apt's `chromium` + `chromium-driver`, installed together so browser/driver versions always match, and natively on arm64 — no emulation, which was failing with `rosetta error` / `qemu-x86_64: could not open ld-linux-x86-64.so.2` on Apple Silicon.
- **Gemfile(.lock)**: dropped the `thin` gem. Its Rack handler is defined as `def self.run(app, **options)`, but Rails 4.2's Rack 1.6.13 calls it with a plain positional Hash, which Ruby 3 no longer auto-converts to keywords — this crashed `rails server` on boot. Production already runs `unicorn` (see `Procfile`), so dropping `thin` just lets `rails server` fall back to `webrick`, which is already a Gemfile dependency and already proven under Ruby 3.1 by Capybara's test server.
- **spec/support/capybara_config.rb**: registered a Chrome driver that passes `--no-sandbox --disable-dev-shm-usage`. Chromium refuses its sandbox running as root (the container's default user); the old Dockerfile handled this for `google-chrome` by patching its launcher script directly, so this replicates it for `chromium` via Selenium options instead.
- **docker-compose.yml**: pinned `db` to `postgres:13` (matching CircleCI's `circleci/postgres:13.1`) instead of unpinned `postgres` (→ 18), which refuses to start against a volume mounted directly at `.../data` rather than its new expected `/var/lib/postgresql` parent mount.

## Test plan

- [x] `docker compose build web` succeeds
- [x] `docker compose up -d db web` boots both containers cleanly
- [x] `docker compose exec web bundle exec rake db:setup` succeeds
- [x] `docker compose exec web bundle exec rake environment elasticsearch:import:model CLASS=Pin INDEX=development_pins FORCE=y` succeeds
- [x] `curl http://localhost:3000/` returns 200 with the expected homepage title
- [ ] Full test suite (`bundle exec rspec`) in the container — not yet run, worth a check before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)